### PR TITLE
add allowAllBrowserActions and additional checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 CLAUDIT-SEC is a read-only, single-file security audit tool for macOS that inspects Claude Desktop and Claude Code configuration, scheduled tasks, extensions, plugins, skills, permissions, and runtime state.
 
-- **`claude_audit.sh`** — Zsh (~1780 lines, requires `jq`) — designed for MDM/CrowdStrike RTR style deployment
+- **`claude_audit.sh`** — Zsh (~1900 lines, requires `jq`) — designed for MDM/CrowdStrike RTR style deployment
 
 This project is built and maintained using [Claude Code](https://docs.anthropic.com/en/docs/claude-code). This file provides architecture context and development guidelines that Claude Code uses when working on the codebase.
 
@@ -15,7 +15,7 @@ The script follows this structure:
 1. **Preflight checks** — OS validation, dependency checks
 2. **User context detection** — single user, explicit `--user`, or all-users scan
 3. **Session directory discovery** — finds `local-agent-mode-sessions/org/user/` paths
-4. **13 data collectors** — each reads specific config files and populates findings
+4. **14 data collectors** — each reads specific config files and populates findings
 5. **Finding aggregation** — counts by severity (WARN, INFO, REVIEW)
 6. **3 output renderers** — ASCII (ANSI color + Unicode tables), HTML (dark theme), JSON (SIEM-ready)
 
@@ -23,11 +23,12 @@ The script follows this structure:
 
 | Collector | Source Files | Key Findings |
 |-----------|-------------|-------------|
-| Desktop Settings | `claude_desktop_config.json` → preferences | keepAwakeEnabled, menuBar, sidebar |
+| Desktop Settings | `claude_desktop_config.json` → preferences | keepAwakeEnabled, allowAllBrowserActions, menuBar, sidebar |
 | Cowork Settings | `cowork_settings.json`, `config.json` | scheduledTasks, webSearch, networkMode |
 | MCP Servers | `claude_desktop_config.json` → mcpServers | Server names, commands, env var keys |
 | Plugins | `installed_plugins.json`, remote manifest, marketplace cache | installed/remote/cached plugins |
-| Connectors | `local_*.json` → remoteMcpServersConfig, `.mcp.json` | web/desktop/not_connected |
+| Plugin Hooks | `hooks/hooks.json` in plugin directories | Shell commands on lifecycle events |
+| Connectors | `local_*.json` → remoteMcpServersConfig, `.mcp.json` | web/desktop/not_connected, egressAllowedDomains, disabledMcpTools |
 | Skills | User skills (6 paths), installed plugin skills (3 paths) — see Key Paths | SKILL.md frontmatter parsing |
 | Scheduled Tasks | `scheduled-tasks.json` | Cron expressions with english translation |
 | Extensions (DXT) | `extensions-installations.json` | Signature status, dangerous tools |

--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@ CLAUDIT gives you that visibility in a single command.
 | Area | What's Checked |
 |------|---------------|
 | 🖥️ **Desktop Settings** | `keepAwakeEnabled`, sidebar/menuBar preferences |
-| 🤖 **CoWork Settings** | Scheduled tasks, web search, network mode, enabled plugins, marketplaces |
+| 🤖 **CoWork Settings** | Scheduled tasks, web search, browser use, network mode, egress policy, enabled plugins, marketplaces |
 | 🔌 **MCP Servers** | Server names, commands, arguments, environment variable keys |
 | 🧩 **Extensions (DXT)** | Installed extensions, signature status, dangerous tool grants |
 | ⚙️ **Extension Settings** | Per-extension allowed directories and configuration |
 | 🚦 **Extension Governance** | Allowlist enabled/disabled, blocklist entries |
 | 📦 **Plugins** | Installed, remote (org-deployed), cached (downloaded) |
+| 🪝 **Plugin Hooks** | Lifecycle hooks executing shell commands (PreToolUse, PostToolUse, Stop, etc.) |
 | 🔗 **Connectors** | OAuth-authenticated web services, desktop integrations |
 | 🎯 **Skills** | User-created, scheduled, session-local, and plugin skills across 9 paths |
 | ⏰ **Scheduled Tasks** | Task names, cron expressions (with plain English translation) |
 | 🔐 **App Config** | OAuth token presence, network mode, extension allowlist keys |
+| 🔇 **Disabled MCP Tools** | Per-session tools explicitly disabled (with dangerous tool callout) |
 | 🏃 **Runtime State** | Running processes, sleep assertions, LaunchAgents, crontab entries |
 | 🍪 **Cookies** | `Cookies` and `Cookies-journal` presence |
 

--- a/claude_audit.sh
+++ b/claude_audit.sh
@@ -41,6 +41,14 @@ MARKETPLACE_AVAILABLE=()
 # Connectors
 CONN_NAMES=() ; CONN_CATS=() ; CONN_TOOLS=() ; CONN_TAGS=()
 
+# Egress & Session Security
+EGRESS_DOMAINS=""            # most-permissive egress policy found across sessions
+EGRESS_UNRESTRICTED=false    # true if any session has ["*"]
+# Disabled MCP tools (tool keys explicitly set to false)
+DISABLED_MCP_TOOLS=()
+# Plugin hooks
+HOOK_PLUGINS=() ; HOOK_EVENTS=() ; HOOK_CMDS=()
+
 # Skills
 SK_NAMES=() ; SK_DESCS=() ; SK_SRCS=() ; SK_PLUGINS=() ; SK_PATHS=()
 
@@ -296,6 +304,7 @@ collect_desktop_settings() { # claude_dir
     COWORK_PREFS[coworkScheduledTasksEnabled]=$(printf '%s' "$prefs" | jq -r '.coworkScheduledTasksEnabled // false')
     COWORK_PREFS[ccdScheduledTasksEnabled]=$(printf '%s' "$prefs" | jq -r '.ccdScheduledTasksEnabled // false')
     COWORK_PREFS[coworkWebSearchEnabled]=$(printf '%s' "$prefs" | jq -r '.coworkWebSearchEnabled // false')
+    COWORK_PREFS[allowAllBrowserActions]=$(printf '%s' "$prefs" | jq -r '.allowAllBrowserActions // false')
 
     [[ "${COWORK_PREFS[coworkScheduledTasksEnabled]}" == "true" ]] && \
         add_finding "WARN" "Cowork Settings" "Scheduled tasks ENABLED — autonomous task execution active" "coworkScheduledTasksEnabled=true"
@@ -303,6 +312,8 @@ collect_desktop_settings() { # claude_dir
         add_finding "WARN" "Cowork Settings" "Code Desktop scheduled tasks ENABLED" "ccdScheduledTasksEnabled=true"
     [[ "${COWORK_PREFS[coworkWebSearchEnabled]}" == "true" ]] && \
         add_finding "WARN" "Cowork Settings" "Web search ENABLED — autonomous internet access" "coworkWebSearchEnabled=true"
+    [[ "${COWORK_PREFS[allowAllBrowserActions]}" == "true" ]] && \
+        add_finding "WARN" "Cowork Settings" "Allow all browser actions ENABLED — Claude can browse any website without asking" "allowAllBrowserActions=true"
 
     # MCP Servers
     local mcp_json
@@ -342,7 +353,7 @@ collect_cowork_settings() { # uses SESSION_DIRS
         mp_keys=$(printf '%s' "$data" | jq -r '.extraKnownMarketplaces // {} | keys[]' 2>/dev/null) || true
         while IFS= read -r mk; do
             [[ -z "$mk" ]] && continue
-            COWORK_MARKETPLACES_JSON["$mk"]=$(printf '%s' "$data" | jq -c --arg k "$mk" '.extraKnownMarketplaces[$k]')
+            COWORK_MARKETPLACES_JSON[$mk]=$(printf '%s' "$data" | jq -c --arg k "$mk" '.extraKnownMarketplaces[$k]')
         done <<< "$mp_keys"
     done
 }
@@ -368,7 +379,7 @@ collect_app_config() { # claude_dir
     has_oauth=$(printf '%s' "$data" | jq -r 'has("oauth:tokenCache") and (.["oauth:tokenCache"] | length > 0)')
     if [[ "$has_oauth" == "true" ]]; then
         add_finding "WARN" "Security" "Unencrypted OAuth token in plaintext config" "oauth:tokenCache present in config.json"
-        APP_CONFIG["oauth:tokenCache"]="[REDACTED]"
+        APP_CONFIG[oauth:tokenCache]="[REDACTED]"
     fi
 
     local dxt_keys
@@ -377,14 +388,14 @@ collect_app_config() { # claude_dir
         [[ -z "$dk" ]] && continue
         local val
         val=$(printf '%s' "$data" | jq -r --arg k "$dk" '.[$k]')
-        APP_CONFIG["$dk"]="$val"
+        APP_CONFIG[$dk]="$val"
         [[ "$val" == "false" ]] && add_finding "WARN" "Security" "Extension allowlist DISABLED: $dk" "Any extension can be installed without approval"
     done <<< "$dxt_keys"
 
     local ant_did
     ant_did=$(printf '%s' "$data" | jq -r '.["ant-did"] // ""')
     if [[ -n "$ant_did" ]]; then
-        RUNTIME_INFO[ant_did]="$ant_did"; APP_CONFIG["ant-did"]="$ant_did"
+        RUNTIME_INFO[ant_did]="$ant_did"; APP_CONFIG[ant-did]="$ant_did"
     fi
 }
 
@@ -460,7 +471,7 @@ collect_extension_settings() { # claude_dir
         [[ -n "$JSON_ERROR" || -z "$data" ]] && continue
         local ext_name
         ext_name=$(basename "$sf" .json)
-        EXT_SETTINGS_JSON["$ext_name"]="$data"
+        EXT_SETTINGS_JSON[$ext_name]="$data"
     done
 }
 
@@ -514,7 +525,7 @@ collect_plugins() { # uses SESSION_DIRS
                     PLG_SCOPES+=("$pscope"); PLG_AUTHORS+=("$pauthor"); PLG_DESCS+=("$pdesc")
                     PLG_MPS+=("$mp_part"); PLG_INSTALLED_ATS+=("$pinst_at"); PLG_INSTALLED_BYS+=("")
                     PLG_IDS+=(""); PLG_SKILL_COUNTS+=("$sk_count")
-                    installed_names["$name_part"]=1
+                    installed_names[$name_part]=1
                 done
             done <<< "$pkeys"
         fi
@@ -553,7 +564,7 @@ collect_plugins() { # uses SESSION_DIRS
                 PLG_SCOPES+=(""); PLG_AUTHORS+=("$rp_author"); PLG_DESCS+=("$rp_desc")
                 PLG_MPS+=("$rp_mp"); PLG_INSTALLED_ATS+=(""); PLG_INSTALLED_BYS+=("$rp_by")
                 PLG_IDS+=("$rp_id"); PLG_SKILL_COUNTS+=("$rp_sk")
-                remote_names["$rp_name"]=1
+                remote_names[$rp_name]=1
                 add_finding "REVIEW" "Plugins" "Remote plugin: $rp_name (v$rp_ver) deployed by $rp_by" "id=$rp_id, marketplace=$rp_mp"
             done
         fi
@@ -621,9 +632,72 @@ collect_plugins() { # uses SESSION_DIRS
     local -A mp_seen; local mp_dedup=()
     local mp_item
     for mp_item in "${MARKETPLACE_AVAILABLE[@]}"; do
-        [[ -z "${mp_seen[$mp_item]:-}" ]] && { mp_dedup+=("$mp_item"); mp_seen["$mp_item"]=1; }
+        [[ -z "${mp_seen[$mp_item]:-}" ]] && { mp_dedup+=("$mp_item"); mp_seen[$mp_item]=1; }
     done
     MARKETPLACE_AVAILABLE=("${mp_dedup[@]+"${mp_dedup[@]}"}")
+}
+
+collect_plugin_hooks() { # uses SESSION_DIRS, home
+    local home="$1"
+    local -A seen_hooks  # "plugin|event|cmd" -> 1
+
+    # Scan paths: cowork cached plugins, CC marketplace plugins, remote plugins
+    local hook_globs=(
+        "cowork_plugins/cache/*/*/hooks/hooks.json"
+        "local_*/.claude/plugins/marketplaces/*/plugins/*/hooks/hooks.json"
+        "local_*/.claude/plugins/marketplaces/*/external_plugins/*/hooks/hooks.json"
+        "remote_cowork_plugins/*/hooks/hooks.json"
+    )
+    local cc_hook_globs=(
+        "$home/.claude/plugins/marketplaces/*/plugins/*/hooks/hooks.json"
+        "$home/.claude/plugins/marketplaces/*/external_plugins/*/hooks/hooks.json"
+    )
+
+    local _hp all_hook_files=()
+    local sess_dir
+    for sess_dir in "${SESSION_DIRS[@]}"; do
+        local glob_pat
+        for glob_pat in "${hook_globs[@]}"; do
+            for _hp in "$sess_dir"/$~glob_pat; do
+                [[ -f "$_hp" ]] && all_hook_files+=("$_hp")
+            done
+        done
+    done
+    local glob_pat
+    for glob_pat in "${cc_hook_globs[@]}"; do
+        for _hp in $~glob_pat; do
+            [[ -f "$_hp" ]] && all_hook_files+=("$_hp")
+        done
+    done
+
+    for _hp in "${all_hook_files[@]}"; do
+        local hdata
+        hdata=$(safe_read_json "$_hp") || true
+        [[ -n "$JSON_ERROR" || -z "$hdata" ]] && continue
+
+        # Derive plugin name from path
+        local pname
+        pname=$(printf '%s' "$_hp" | sed -E 's|.*/plugins/([^/]+)/hooks/.*|\1|; s|.*/cache/[^/]+/([^/]+)/[^/]+/hooks/.*|\1|; s|.*/remote_cowork_plugins/([^/]+)/hooks/.*|\1|')
+        [[ "$pname" == "$_hp" ]] && pname="unknown"
+
+        local events
+        events=$(printf '%s' "$hdata" | jq -r '.hooks // {} | keys[]' 2>/dev/null) || true
+        while IFS= read -r ev; do
+            [[ -z "$ev" ]] && continue
+            local cmds
+            cmds=$(printf '%s' "$hdata" | jq -r --arg e "$ev" '.hooks[$e][]?.hooks[]? | select(.type == "command") | .command // empty' 2>/dev/null) || true
+            while IFS= read -r cmd; do
+                [[ -z "$cmd" ]] && continue
+                local dedup_key="$pname|$ev|$cmd"
+                [[ -n "${seen_hooks[$dedup_key]:-}" ]] && continue
+                seen_hooks[$dedup_key]=1
+                HOOK_PLUGINS+=("$pname"); HOOK_EVENTS+=("$ev"); HOOK_CMDS+=("$cmd")
+            done <<< "$cmds"
+        done <<< "$events"
+    done
+
+    ((${#HOOK_PLUGINS[@]} > 0)) && add_finding "WARN" "Security" "${#HOOK_PLUGINS[@]} plugin hook(s) found executing commands on lifecycle events" \
+        "Plugins: $(printf '%s\n' "${HOOK_PLUGINS[@]}" | sort -u | tr '\n' ',' | sed 's/,$//')"
 }
 
 collect_connectors() { # uses SESSION_DIRS, EXT_*, MCP_*
@@ -636,6 +710,26 @@ collect_connectors() { # uses SESSION_DIRS, EXT_*, MCP_*
             local data
             data=$(safe_read_json "$entry") || true
             [[ -n "$JSON_ERROR" || -z "$data" ]] && continue
+
+            # Egress policy (most-permissive wins)
+            local egress
+            egress=$(printf '%s' "$data" | jq -r '.egressAllowedDomains // empty | if type == "array" then if . == ["*"] then "*" elif length > 0 then join(", ") else empty end else . end' 2>/dev/null) || true
+            if [[ "$egress" == "*" ]]; then
+                EGRESS_UNRESTRICTED=true; EGRESS_DOMAINS="*"
+            elif [[ -n "$egress" && "$EGRESS_UNRESTRICTED" != "true" ]]; then
+                EGRESS_DOMAINS="$egress"
+            fi
+
+            # Disabled MCP tools
+            local disabled
+            disabled=$(printf '%s' "$data" | jq -r '.enabledMcpTools // {} | to_entries[] | select(.value == false) | .key' 2>/dev/null) || true
+            while IFS= read -r dk; do
+                [[ -z "$dk" ]] && continue
+                local already=false; local di
+                for ((di=0; di<${#DISABLED_MCP_TOOLS[@]}; di++)); do [[ "${DISABLED_MCP_TOOLS[$di]}" == "$dk" ]] && { already=true; break; }; done
+                [[ "$already" == "false" ]] && DISABLED_MCP_TOOLS+=("$dk")
+            done <<< "$disabled"
+
             local ts rmc_len
             ts=$(printf '%s' "$data" | jq -r '.lastActivityAt // 0')
             rmc_len=$(printf '%s' "$data" | jq '.remoteMcpServersConfig // [] | length')
@@ -647,8 +741,8 @@ collect_connectors() { # uses SESSION_DIRS, EXT_*, MCP_*
                 [[ -z "$srv_name" ]] && continue
                 local key="${(L)srv_name}"  # lowercase
                 if [[ -z "${best_ts[$key]:-}" ]] || ((ts > best_ts[$key])); then
-                    best_ts["$key"]="$ts"
-                    best_conn_json["$key"]="$srv_name|$(printf '%s' "$data" | jq -r ".remoteMcpServersConfig[$si].tools // [] | length")"
+                    best_ts[$key]="$ts"
+                    best_conn_json[$key]="$srv_name|$(printf '%s' "$data" | jq -r ".remoteMcpServersConfig[$si].tools // [] | length")"
                 fi
             done
         done
@@ -662,7 +756,7 @@ collect_connectors() { # uses SESSION_DIRS, EXT_*, MCP_*
             local cname="${val%%|*}" ctc="${val#*|}"
             CONN_NAMES+=("$cname"); CONN_CATS+=("web"); CONN_TOOLS+=("$ctc"); CONN_TAGS+=("")
             local norm; norm=$(printf '%s' "$cname" | tr '[:upper:]' '[:lower:]' | tr ' _' '--' | tr -cd 'a-z0-9-')
-            [[ -n "$norm" ]] && seen_web_norm["$norm"]=1
+            [[ -n "$norm" ]] && seen_web_norm[$norm]=1
         done < <(printf '%s\n' "${(k)best_conn_json[@]}" | sort)
     fi
 
@@ -690,7 +784,7 @@ collect_connectors() { # uses SESSION_DIRS, EXT_*, MCP_*
             while IFS= read -r sn; do
                 [[ -z "$sn" ]] && continue
                 local norm; norm=$(printf '%s' "$sn" | tr '[:upper:]' '[:lower:]' | tr ' _' '--' | tr -cd 'a-z0-9-')
-                [[ -z "${seen_web_norm[$norm]:-}" ]] && not_connected["$norm"]="$sn"
+                [[ -z "${seen_web_norm[$norm]:-}" ]] && not_connected[$norm]="$sn"
             done <<< "$srv_names"
         done
     done
@@ -719,6 +813,24 @@ collect_connectors() { # uses SESSION_DIRS, EXT_*, MCP_*
         [[ "${CONN_CATS[$i]}" == "web" ]] && { [[ -n "$web_names" ]] && web_names+=", "; web_names+="${CONN_NAMES[$i]}"; }
     done
     ((web_count > 0)) && add_finding "INFO" "Connectors" "$web_count web connector(s) authenticated: $web_names"
+
+    # Egress findings
+    if [[ "$EGRESS_UNRESTRICTED" == "true" ]]; then
+        add_finding "WARN" "Security" "Cowork VM egress is UNRESTRICTED — all domains allowed" "egressAllowedDomains=[\"*\"]"
+    elif [[ -n "$EGRESS_DOMAINS" ]]; then
+        add_finding "INFO" "Cowork Settings" "Cowork VM egress restricted to specific domains" "egressAllowedDomains: $EGRESS_DOMAINS"
+    fi
+
+    # Disabled MCP tools findings
+    local disabled_dangerous=""
+    for ((i=0; i<${#DISABLED_MCP_TOOLS[@]}; i++)); do
+        local tk="${DISABLED_MCP_TOOLS[$i]}"
+        if [[ "$tk" == *execute_javascript* || "$tk" == *write_file* || "$tk" == *edit_file* || "$tk" == *run_command* ]]; then
+            [[ -n "$disabled_dangerous" ]] && disabled_dangerous+=", "
+            disabled_dangerous+="$tk"
+        fi
+    done
+    ((${#DISABLED_MCP_TOOLS[@]} > 0)) && add_finding "INFO" "Cowork Settings" "${#DISABLED_MCP_TOOLS[@]} MCP tool(s) explicitly disabled" "${disabled_dangerous:+Includes dangerous tools: $disabled_dangerous}"
 }
 
 collect_skills() { # uses SESSION_DIRS, home
@@ -1046,7 +1158,7 @@ collect_cookies() { # claude_dir
     for label in Cookies Cookies-journal; do
         _path="$claude_dir/$label"
         [[ -e "$_path" ]] || continue
-        COOKIES_INFO["${label}_present"]="true"
+        COOKIES_INFO[${label}_present]="true"
     done
 }
 
@@ -1085,6 +1197,14 @@ build_recommendations() {
 
     [[ "${COWORK_PREFS[coworkWebSearchEnabled]:-false}" == "true" ]] && \
         RECOMMENDATIONS+=("Cowork web search enabled — autonomous internet access")
+    [[ "${COWORK_PREFS[allowAllBrowserActions]:-false}" == "true" ]] && \
+        RECOMMENDATIONS+=("Allow all browser actions enabled — Claude can browse any website without asking")
+
+    [[ "$EGRESS_UNRESTRICTED" == "true" ]] && \
+        RECOMMENDATIONS+=("Cowork VM network egress is unrestricted — all domains reachable")
+
+    ((${#HOOK_PLUGINS[@]} > 0)) && \
+        RECOMMENDATIONS+=("${#HOOK_PLUGINS[@]} plugin hook(s) execute commands on lifecycle events — review for data exfiltration risk")
 
     local remote_names=""
     for ((i=0; i<${#PLG_SRCS[@]}; i++)); do
@@ -1211,13 +1331,22 @@ BANNER
     fi
 
     # Cowork Settings
-    local cst="${COWORK_PREFS[coworkScheduledTasksEnabled]:-false}" ccd="${COWORK_PREFS[ccdScheduledTasksEnabled]:-false}" cws="${COWORK_PREFS[coworkWebSearchEnabled]:-false}"
+    local cst="${COWORK_PREFS[coworkScheduledTasksEnabled]:-false}" ccd="${COWORK_PREFS[ccdScheduledTasksEnabled]:-false}" cws="${COWORK_PREFS[coworkWebSearchEnabled]:-false}" aba="${COWORK_PREFS[allowAllBrowserActions]:-false}"
     if [[ "$quiet" != "true" ]]; then
         _section_hdr "COWORK SETTINGS"
         printf '  scheduledTasksEnabled:         %s' "$(_on_off "$cst")"; [[ "$cst" == "true" ]] && printf '   ⚠ Autonomous task execution'; echo
         printf '  ccdScheduledTasksEnabled:      %s' "$(_on_off "$ccd")"; [[ "$ccd" == "true" ]] && printf '   ⚠ Code Desktop scheduled tasks'; echo
         printf '  webSearchEnabled:              %s' "$(_on_off "$cws")"; [[ "$cws" == "true" ]] && printf '   ⚠ Autonomous internet access'; echo
+        printf '  allowAllBrowserActions:        %s' "$(_on_off "$aba")"; [[ "$aba" == "true" ]] && printf '   ⚠ Browse any website without asking'; echo
         printf '  networkMode:                   %s\n' "${COWORK_NETWORK_MODE:-$(_dim "-")}"
+        if [[ "$EGRESS_UNRESTRICTED" == "true" ]]; then
+            printf '  egressAllowedDomains:          %s   ⚠ All domains reachable\n' "$(_on_off true)"
+        elif [[ -n "$EGRESS_DOMAINS" ]]; then
+            printf '  egressAllowedDomains:          %s\n' "$(_dim "restricted")"
+        else
+            printf '  egressAllowedDomains:          %s\n' "$(_dim "-")"
+        fi
+        ((${#DISABLED_MCP_TOOLS[@]}>0)) && printf '  Disabled MCP tools:            %d tool(s)\n' "${#DISABLED_MCP_TOOLS[@]}"
         ((${#COWORK_ENABLED_PLUGINS[@]}>0)) && printf '  Enabled plugins:               %s\n' "$(IFS=', '; echo "${COWORK_ENABLED_PLUGINS[*]}")"
         for mk in "${(k)COWORK_MARKETPLACES_JSON[@]}"; do
             local st sr; st=$(printf '%s' "${COWORK_MARKETPLACES_JSON[$mk]}" | jq -r '.source.source // "?"' 2>/dev/null)
@@ -1229,7 +1358,21 @@ BANNER
         [[ "$cst" == "true" ]] && wi+=("$(printf '  scheduledTasksEnabled:         %s   ⚠ Autonomous task execution' "$(_on_off "$cst")")")
         [[ "$ccd" == "true" ]] && wi+=("$(printf '  ccdScheduledTasksEnabled:      %s   ⚠ Code Desktop scheduled tasks' "$(_on_off "$ccd")")")
         [[ "$cws" == "true" ]] && wi+=("$(printf '  webSearchEnabled:              %s   ⚠ Autonomous internet access' "$(_on_off "$cws")")")
+        [[ "$aba" == "true" ]] && wi+=("$(printf '  allowAllBrowserActions:        %s   ⚠ Browse any website without asking' "$(_on_off "$aba")")")
+        [[ "$EGRESS_UNRESTRICTED" == "true" ]] && wi+=("$(printf '  egressAllowedDomains:          %s   ⚠ All domains reachable' "$(_on_off true)")")
         if ((${#wi[@]}>0)); then _section_hdr "COWORK SETTINGS"; for w in "${wi[@]}"; do echo "$w"; done; echo; fi
+    fi
+
+    # Plugin Hooks
+    if [[ "$quiet" != "true" || ${#HOOK_PLUGINS[@]} -gt 0 ]]; then
+        if ((${#HOOK_PLUGINS[@]}>0)); then
+            _section_hdr "PLUGIN HOOKS"
+            local rows=""
+            for ((i=0;i<${#HOOK_PLUGINS[@]};i++)); do
+                [[ -n "$rows" ]] && rows+=$'\n'
+                rows+="$(truncate_str "${HOOK_PLUGINS[$i]}" 24)|$(truncate_str "${HOOK_EVENTS[$i]}" 18)|$(truncate_str "${HOOK_CMDS[$i]}" 48)"
+            done; ascii_table "Plugin|Event|Command" "$rows" "24|18|48"; echo
+        fi
     fi
 
     # MCP Servers
@@ -1315,7 +1458,7 @@ BANNER
                 prows+="$(truncate_str "${SK_NAMES[$idx]}" 24)|$(truncate_str "${SK_PLUGINS[$idx]:-unknown}" 22)|$(truncate_str "${SK_DESCS[$idx]}" 40)"
             done; ascii_table "Skill|Plugin|Description" "$prows" "24|22|40"
         elif ((${#psk_i[@]}>0)); then
-            local -A pns; for idx in "${psk_i[@]}"; do pns["${SK_PLUGINS[$idx]:-unknown}"]=1; done
+            local -A pns; for idx in "${psk_i[@]}"; do pns[${SK_PLUGINS[$idx]:-unknown}]=1; done
             echo "  Plugin skills: ${#psk_i[@]} across $(IFS=', '; echo "${(k)pns[*]}")"
         fi
         ((${#usk_i[@]}==0 && ${#psk_i[@]}==0)) && echo "  No skills found."; echo
@@ -1459,29 +1602,48 @@ HTMLEOF
     fi
 
     # Cowork Settings
-    local cst="${COWORK_PREFS[coworkScheduledTasksEnabled]:-false}" ccd="${COWORK_PREFS[ccdScheduledTasksEnabled]:-false}" cws="${COWORK_PREFS[coworkWebSearchEnabled]:-false}"
+    local cst="${COWORK_PREFS[coworkScheduledTasksEnabled]:-false}" ccd="${COWORK_PREFS[ccdScheduledTasksEnabled]:-false}" cws="${COWORK_PREFS[coworkWebSearchEnabled]:-false}" aba="${COWORK_PREFS[allowAllBrowserActions]:-false}"
     if [[ "$quiet" != "true" ]]; then
         echo '<details open><summary>Cowork Settings</summary><div class="detail-content">'
         for tuple in "coworkScheduledTasksEnabled|scheduledTasksEnabled|Autonomous task execution" \
                      "ccdScheduledTasksEnabled|ccdScheduledTasksEnabled|Code Desktop scheduled tasks" \
-                     "coworkWebSearchEnabled|webSearchEnabled|Autonomous internet access"; do
+                     "coworkWebSearchEnabled|webSearchEnabled|Autonomous internet access" \
+                     "allowAllBrowserActions|allowAllBrowserActions|Browse any website without asking"; do
             IFS='|' read -r key label wmsg <<< "$tuple"; local val="${COWORK_PREFS[$key]:-false}"
             printf '<div class="setting-row"><span class="setting-key">%s</span><span class="setting-val">%s</span>' "$(_h "$label")" "$(_on_off_html "$val")"
             [[ "$val" == "true" ]] && printf '<span class="setting-warn">&#9888; %s</span>' "$(_h "$wmsg")"; echo '</div>'
         done
         printf '<div class="setting-row"><span class="setting-key">networkMode</span><span class="setting-val">%s</span></div>\n' "$(_h "${COWORK_NETWORK_MODE:-"-"}")"
+        if [[ "$EGRESS_UNRESTRICTED" == "true" ]]; then
+            printf '<div class="setting-row"><span class="setting-key">egressAllowedDomains</span><span class="setting-val">%s</span><span class="setting-warn">&#9888; All domains reachable</span></div>\n' "$(_on_off_html true)"
+        elif [[ -n "$EGRESS_DOMAINS" ]]; then
+            printf '<div class="setting-row"><span class="setting-key">egressAllowedDomains</span><span class="setting-val">%s</span></div>\n' "$(_h "restricted")"
+        fi
+        ((${#DISABLED_MCP_TOOLS[@]}>0)) && printf '<div class="setting-row"><span class="setting-key">Disabled MCP tools</span><span class="setting-val">%d tool(s)</span></div>\n' "${#DISABLED_MCP_TOOLS[@]}"
         ((${#COWORK_ENABLED_PLUGINS[@]}>0)) && printf '<div class="setting-row"><span class="setting-key">Enabled plugins</span><span class="setting-val">%s</span></div>\n' "$(_h "$(IFS=', '; echo "${COWORK_ENABLED_PLUGINS[*]}")")"
         echo '</div></details>'
     else
-        if [[ "$cst" == "true" || "$ccd" == "true" || "$cws" == "true" ]]; then
+        if [[ "$cst" == "true" || "$ccd" == "true" || "$cws" == "true" || "$aba" == "true" || "$EGRESS_UNRESTRICTED" == "true" ]]; then
             echo '<details open><summary>Cowork Settings</summary><div class="detail-content">'
             for tuple in "coworkScheduledTasksEnabled|scheduledTasksEnabled|Autonomous task execution" \
                          "ccdScheduledTasksEnabled|ccdScheduledTasksEnabled|Code Desktop scheduled tasks" \
-                         "coworkWebSearchEnabled|webSearchEnabled|Autonomous internet access"; do
+                         "coworkWebSearchEnabled|webSearchEnabled|Autonomous internet access" \
+                         "allowAllBrowserActions|allowAllBrowserActions|Browse any website without asking"; do
                 IFS='|' read -r key label wmsg <<< "$tuple"
                 [[ "${COWORK_PREFS[$key]:-false}" == "true" ]] && printf '<div class="setting-row"><span class="setting-key">%s</span><span class="setting-val">%s</span><span class="setting-warn">&#9888; %s</span></div>\n' "$(_h "$label")" "$(_on_off_html true)" "$(_h "$wmsg")"
-            done; echo '</div></details>'
+            done
+            [[ "$EGRESS_UNRESTRICTED" == "true" ]] && printf '<div class="setting-row"><span class="setting-key">egressAllowedDomains</span><span class="setting-val">%s</span><span class="setting-warn">&#9888; All domains reachable</span></div>\n' "$(_on_off_html true)"
+            echo '</div></details>'
         fi
+    fi
+
+    # Plugin Hooks
+    if ((${#HOOK_PLUGINS[@]}>0)); then
+        echo '<details open><summary>Plugin Hooks</summary><div class="detail-content">'
+        echo '<table><tr><th>Plugin</th><th>Event</th><th>Command</th></tr>'
+        for ((i=0;i<${#HOOK_PLUGINS[@]};i++)); do
+            printf '<tr><td>%s</td><td>%s</td><td><code>%s</code></td></tr>\n' "$(_h "${HOOK_PLUGINS[$i]}")" "$(_h "${HOOK_EVENTS[$i]}")" "$(_h "${HOOK_CMDS[$i]}")"
+        done; echo '</table></div></details>'
     fi
 
     # MCP Servers
@@ -1559,7 +1721,7 @@ HTMLEOF
                 printf '<tr><td>%s</td><td>%s</td><td>%s</td></tr>\n' "$(_h "${SK_NAMES[$i]}")" "$(_h "${SK_PLUGINS[$i]:-unknown}")" "$(_h "${SK_DESCS[$i]:0:80}")"
             done; echo '</table>'
         elif ((n_psk>0)); then
-            local -A pns; for ((i=0;i<${#SK_SRCS[@]};i++)); do [[ "${SK_SRCS[$i]}" == "plugin" ]] && pns["${SK_PLUGINS[$i]:-unknown}"]=1; done
+            local -A pns; for ((i=0;i<${#SK_SRCS[@]};i++)); do [[ "${SK_SRCS[$i]}" == "plugin" ]] && pns[${SK_PLUGINS[$i]:-unknown}]=1; done
             printf '<p>Plugin skills: %d across %s</p>\n' "$n_psk" "$(_h "$(IFS=', '; echo "${(k)pns[*]}")")"; fi
         ((n_usk==0&&n_psk==0)) && echo '<p>No skills found.</p>'; echo '</div></details>'
     fi
@@ -1658,11 +1820,29 @@ render_json() {
     done; ext_j+="]"
 
     local dp_j="{\"keepAwakeEnabled\":${DESKTOP_PREFS[keepAwakeEnabled]:-false},\"menuBarEnabled\":${DESKTOP_PREFS[menuBarEnabled]:-false}}"
-    local cp_j="{\"coworkScheduledTasksEnabled\":${COWORK_PREFS[coworkScheduledTasksEnabled]:-false},\"ccdScheduledTasksEnabled\":${COWORK_PREFS[ccdScheduledTasksEnabled]:-false},\"coworkWebSearchEnabled\":${COWORK_PREFS[coworkWebSearchEnabled]:-false}}"
+    local cp_j="{\"coworkScheduledTasksEnabled\":${COWORK_PREFS[coworkScheduledTasksEnabled]:-false},\"ccdScheduledTasksEnabled\":${COWORK_PREFS[ccdScheduledTasksEnabled]:-false},\"coworkWebSearchEnabled\":${COWORK_PREFS[coworkWebSearchEnabled]:-false},\"allowAllBrowserActions\":${COWORK_PREFS[allowAllBrowserActions]:-false}}"
 
-    printf '{"timestamp":%s,"hostname":%s,"username":%s,"home_dir":%s,"findings":%s,"desktop_prefs":%s,"cowork_prefs":%s,"cowork_network_mode":%s,"mcp_servers":%s,"plugins":%s,"connectors":%s,"skills":%s,"scheduled_tasks":%s,"extensions":%s,"blocklist_entries":%d,"blocklist_status":%s,"claude_code_settings":%s,"warn_count":%d,"info_count":%d}' \
+    local egress_j
+    if [[ "$EGRESS_UNRESTRICTED" == "true" ]]; then egress_j='["*"]'
+    elif [[ -n "$EGRESS_DOMAINS" ]]; then
+        egress_j="["; local first=true; local _d
+        while IFS=', ' read -rA _dlist; do for _d in "${_dlist[@]}"; do
+            [[ -z "$_d" ]] && continue; [[ "$first" == "true" ]] && first=false || egress_j+=","
+            egress_j+="$(_jstr "$_d")"
+        done; done <<< "$EGRESS_DOMAINS"; egress_j+="]"
+    else egress_j="null"; fi
+
+    local dtool_j="["; for ((i=0;i<${#DISABLED_MCP_TOOLS[@]};i++)); do ((i>0)) && dtool_j+=","
+        dtool_j+="$(_jstr "${DISABLED_MCP_TOOLS[$i]}")"; done; dtool_j+="]"
+
+    local hook_j="["; for ((i=0;i<${#HOOK_PLUGINS[@]};i++)); do ((i>0)) && hook_j+=","
+        hook_j+="{\"plugin\":$(_jstr "${HOOK_PLUGINS[$i]}"),\"event\":$(_jstr "${HOOK_EVENTS[$i]}"),\"command\":$(_jstr "${HOOK_CMDS[$i]}")}"
+    done; hook_j+="]"
+
+    printf '{"timestamp":%s,"hostname":%s,"username":%s,"home_dir":%s,"findings":%s,"desktop_prefs":%s,"cowork_prefs":%s,"cowork_network_mode":%s,"egress_allowed_domains":%s,"disabled_mcp_tools":%s,"plugin_hooks":%s,"mcp_servers":%s,"plugins":%s,"connectors":%s,"skills":%s,"scheduled_tasks":%s,"extensions":%s,"blocklist_entries":%d,"blocklist_status":%s,"claude_code_settings":%s,"warn_count":%d,"info_count":%d}' \
         "$(_jstr "$TIMESTAMP")" "$(_jstr "$HOSTNAME_VAL")" "$(_jstr "$AUDIT_USER")" "$(_jstr "$HOME_DIR")" \
         "$findings_j" "$dp_j" "$cp_j" "$(_jstr "$COWORK_NETWORK_MODE")" \
+        "$egress_j" "$dtool_j" "$hook_j" \
         "$mcp_j" "$plg_j" "$conn_j" "$sk_j" "$st_j" "$ext_j" \
         "$BLOCKLIST_ENTRIES" "$(_jstr "$BLOCKLIST_STATUS")" "$CLAUDE_CODE_JSON" \
         "$WARN_COUNT" "$INFO_COUNT" | \
@@ -1682,6 +1862,8 @@ run_audit() {
     PLG_DESCS=(); PLG_MPS=(); PLG_INSTALLED_ATS=(); PLG_INSTALLED_BYS=()
     PLG_IDS=(); PLG_SKILL_COUNTS=(); MARKETPLACE_AVAILABLE=()
     CONN_NAMES=(); CONN_CATS=(); CONN_TOOLS=(); CONN_TAGS=()
+    EGRESS_DOMAINS=""; EGRESS_UNRESTRICTED=false; DISABLED_MCP_TOOLS=()
+    HOOK_PLUGINS=(); HOOK_EVENTS=(); HOOK_CMDS=()
     SK_NAMES=(); SK_DESCS=(); SK_SRCS=(); SK_PLUGINS=(); SK_PATHS=()
     ST_IDS=(); ST_CRONS=(); ST_CRON_ENG=(); ST_ENABLEDS=(); ST_FPATHS=()
     ST_CREATED=(); ST_SNAMES=(); ST_SDESCS=(); ST_PROMPTS=()
@@ -1702,6 +1884,7 @@ run_audit() {
     collect_extensions "$claude_dir"
     collect_extension_settings "$claude_dir"
     collect_plugins
+    collect_plugin_hooks "$home"
     collect_connectors
     collect_skills "$home"
     collect_scheduled_tasks

--- a/docs/findings-reference.md
+++ b/docs/findings-reference.md
@@ -15,14 +15,15 @@
 5. [📂 Extension Settings](#5--extension-settings)
 6. [🛡️ Extension Governance (Blocklist & Allowlist)](#6--extension-governance-blocklist--allowlist)
 7. [🔗 Plugins](#7--plugins)
-8. [🌐 Connectors](#8--connectors)
-9. [🎯 Skills](#9--skills)
-10. [⏰ Scheduled Tasks](#10--scheduled-tasks)
-11. [⚙️ App Config (config.json)](#11--app-config-configjson)
-12. [💻 Claude Code Settings](#12--claude-code-settings)
-13. [🏃 Runtime State](#13--runtime-state)
-14. [🍪 Cookies](#14--cookies)
-15. [📊 Severity Level Reference](#15--severity-level-reference)
+8. [🪝 Plugin Hooks](#8--plugin-hooks)
+9. [🌐 Connectors](#9--connectors)
+10. [🎯 Skills](#10--skills)
+11. [⏰ Scheduled Tasks](#11--scheduled-tasks)
+12. [⚙️ App Config (config.json)](#12--app-config-configjson)
+13. [💻 Claude Code Settings](#13--claude-code-settings)
+14. [🏃 Runtime State](#14--runtime-state)
+15. [🍪 Cookies](#15--cookies)
+16. [📊 Severity Level Reference](#16--severity-level-reference)
 
 ---
 
@@ -111,6 +112,41 @@ Cowork is Claude Desktop's agentic mode. These checks examine settings that cont
   - 🤖 **AI enablement**: Web search significantly expands Claude's capabilities, allowing it to retrieve current information, check documentation, and research topics. Understanding its status helps assess the scope of AI data flows.
 - **Severity**: ⚠️ `WARN` — Autonomous internet access is a significant capability expansion that should be intentionally configured.
 - **Recommendation**: Disable if the organization requires AI tools to operate without external internet access. If enabled, ensure network monitoring covers Claude's outbound traffic.
+
+---
+
+### 🌍 Allow All Browser Actions (allowAllBrowserActions)
+
+- **What**: Checks whether `preferences.allowAllBrowserActions` is `true`. When enabled, Claude can browse and interact with any website in Chrome without asking for user approval per action.
+- **Why it matters**:
+  - 🔴 **Risk**: With this enabled, Claude can navigate to arbitrary URLs, fill forms, click buttons, and execute JavaScript in the browser without per-action user consent. This expands the attack surface to include any website Claude can reach — a compromised or prompt-injected session could interact with sensitive web applications (banking, admin panels, internal tools) without the user being prompted.
+  - 📜 **Compliance**: Unrestricted browser automation may violate acceptable use policies, especially in environments where web access is governed. Autonomous interactions with third-party websites can create unintended data sharing or contractual exposure.
+  - 🤖 **AI enablement**: This setting is designed for power users who want seamless browser automation without constant approval prompts. It is a convenience/security trade-off.
+- **Severity**: ⚠️ `WARN` — Unrestricted browser actions represent a significant capability expansion.
+- **Recommendation**: Disable unless the user specifically needs autonomous browser interaction. When enabled, ensure network-level controls (proxy, DNS filtering) limit reachable websites. Review the Chrome Control extension's allowed actions.
+
+---
+
+### 🌐 Egress Allowed Domains (egressAllowedDomains)
+
+- **What**: Reads `egressAllowedDomains` from `local_*.json` session files. This field controls which domains the Cowork VM can reach over the network. A value of `["*"]` means unrestricted egress; a specific domain list means traffic is restricted to those domains only.
+- **Why it matters**:
+  - 🔴 **Risk**: When set to `["*"]`, the Cowork sandbox has unrestricted network egress — it can connect to any domain on the internet. This means autonomous code execution inside the VM can exfiltrate data to arbitrary endpoints, download malicious payloads, or interact with unauthorized services. A restricted domain list is the primary network boundary control for the Cowork VM.
+  - 📜 **Compliance**: Network segmentation and egress filtering are fundamental security controls (CIS, NIST 800-53 SC-7). Unrestricted egress from an AI agent's sandbox violates these controls.
+  - 🤖 **AI enablement**: Egress domains define what external resources are available to Cowork sessions. Development workflows may need access to package registries (npmjs.org, pypi.org), while more restricted sessions should be limited to specific domains.
+- **Severity**: ⚠️ `WARN` if `["*"]` (unrestricted), ℹ️ `INFO` if restricted to specific domains.
+- **Recommendation**: If egress is unrestricted (`["*"]`), investigate whether this is intentional. Work with the organization to define an appropriate domain allowlist. For restricted sessions, review the domain list to ensure only necessary domains are included.
+
+---
+
+### 🔇 Disabled MCP Tools (enabledMcpTools)
+
+- **What**: Reads `enabledMcpTools` from `local_*.json` session files and identifies tools explicitly set to `false` (disabled). Reports the total count and specifically calls out dangerous tools that have been disabled (e.g., `write_file`, `edit_file`, `execute_javascript`, `run_command`).
+- **Why it matters**:
+  - 🔍 **Visibility**: Disabled MCP tools show that the user or system has intentionally restricted certain capabilities. This is a positive security signal — it means dangerous tools have been turned off. However, the list also reveals what tools are available (everything not in the disabled list is implicitly enabled).
+  - 🤖 **AI enablement**: Users can fine-tune which MCP tools are active per session. The disabled list reflects conscious security decisions about tool access.
+- **Severity**: ℹ️ `INFO` — Disabling tools is a positive action, but the inventory is useful for understanding the security posture.
+- **Recommendation**: Review the disabled tools list to confirm dangerous tools are disabled as expected. Verify that no critical restrictions have been removed.
 
 ---
 
@@ -270,7 +306,36 @@ Plugins extend Claude Cowork's capabilities. They come in three categories: inst
 
 ---
 
-## 8. 🌐 Connectors
+## 8. 🪝 Plugin Hooks
+
+**Source files:** `hooks/hooks.json` inside plugin directories (cowork cached plugins, CC marketplace plugins, remote plugins)
+
+Plugin hooks are shell commands that plugins register to run at specific lifecycle events during a Claude session. They execute automatically without user interaction.
+
+---
+
+### ⚠️ Plugin Hook Executing Commands
+
+- **What**: Scans for `hooks/hooks.json` files inside plugin directories across 6 glob patterns (cowork cached plugins, CC marketplace plugins, remote plugins, and session-local copies). For each hooks file found, CLAUDIT extracts the hook events (`Stop`, `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart`, etc.) and the shell commands they execute. Results are deduplicated by plugin name, event, and command.
+- **Why it matters**:
+  - 🔴 **Risk**: Plugin hooks are an arbitrary command execution channel. A hook registered on `PreToolUse` or `PostToolUse` runs a shell command **on every single tool call** — potentially hundreds of times per session. A hook on `Stop` runs when the session ends, and `UserPromptSubmit` runs on every user message. A malicious or compromised plugin could use hooks to:
+    - **Exfiltrate data**: A `Stop` hook could `curl` session contents to an external server
+    - **Modify behavior**: A `PreToolUse` hook could alter tool inputs or inject instructions
+    - **Persist access**: Hooks run with the user's full permissions and can write files, install software, or modify system configuration
+  - 📜 **Compliance**: Hooks are effectively background code execution triggered by AI agent activity. They should be inventoried and reviewed as part of software approval processes. Many organizations require visibility into all code execution paths.
+  - 🤖 **AI enablement**: Hooks are a legitimate plugin capability for observability (logging, notifications), guardrails (security checks before tool use), and workflow automation (Slack notifications on task completion). The audit ensures visibility into what hooks are active.
+- **Severity**: ⚠️ `WARN` — Plugin hooks represent a command execution channel that should be reviewed.
+- **Recommendation**: Review each hook's command to understand what it does. Pay special attention to hooks that:
+  - Make network calls (curl, wget, python scripts with HTTP)
+  - Run on high-frequency events (PreToolUse, PostToolUse)
+  - Reference external paths outside `${CLAUDE_PLUGIN_ROOT}`
+  - Execute arbitrary interpreters (python3, node, bash) with complex scripts
+
+  Remove or disable plugins with hooks that are not understood or not needed.
+
+---
+
+## 9. 🌐 Connectors
 
 **Source files:** `local_*.json` (session files) → `remoteMcpServersConfig`, `.mcp.json` (from remote plugins), extensions, MCP servers
 
@@ -300,7 +365,7 @@ Connectors represent all the external services and integrations that Claude can 
 
 ---
 
-## 9. 🎯 Skills
+## 10. 🎯 Skills
 
 **Source paths:** 9 different filesystem locations (see Architecture section)
 
@@ -341,7 +406,7 @@ Skills are SKILL.md files that define reusable prompts and instructions for Clau
 
 ---
 
-## 10. ⏰ Scheduled Tasks
+## 11. ⏰ Scheduled Tasks
 
 **Source file:** `scheduled-tasks.json` (per session)
 
@@ -371,7 +436,7 @@ Scheduled tasks are cron-scheduled autonomous Claude sessions. Each task has a c
 
 ---
 
-## 11. ⚙️ App Config (config.json)
+## 12. ⚙️ App Config (config.json)
 
 **Source file:** `~/Library/Application Support/Claude/config.json`
 
@@ -401,7 +466,7 @@ The app config contains application-level settings including OAuth tokens, netwo
 
 ---
 
-## 12. 💻 Claude Code Settings
+## 13. 💻 Claude Code Settings
 
 **Source file:** `~/.claude/settings.json`
 
@@ -421,7 +486,7 @@ Claude Code is the CLI-based Claude interface. Its settings file contains permis
 
 ---
 
-## 13. 🏃 Runtime State
+## 14. 🏃 Runtime State
 
 **Source:** System commands (`pgrep`, `pmset`, `crontab`, filesystem)
 
@@ -488,7 +553,7 @@ Runtime checks examine the live state of the system to detect Claude-related pro
 
 ---
 
-## 14. 🍪 Cookies
+## 15. 🍪 Cookies
 
 **Source files:** `~/Library/Application Support/Claude/Cookies`, `~/Library/Application Support/Claude/Cookies-journal`
 
@@ -507,7 +572,7 @@ Claude Desktop (as an Electron app) maintains browser-like cookie storage.
 
 ---
 
-## 15. 📊 Severity Level Reference
+## 16. 📊 Severity Level Reference
 
 CLAUDIT uses five severity levels. Here is what each means and when it is applied:
 
@@ -531,16 +596,19 @@ Here is a complete catalog of every `add_finding` call in CLAUDIT, organized by 
 | 2 | Cowork Settings | Scheduled tasks ENABLED | `preferences.coworkScheduledTasksEnabled == true` |
 | 3 | Cowork Settings | Code Desktop scheduled tasks ENABLED | `preferences.ccdScheduledTasksEnabled == true` |
 | 4 | Cowork Settings | Web search ENABLED | `preferences.coworkWebSearchEnabled == true` |
-| 5 | Security | Unencrypted OAuth token in plaintext config | `oauth:tokenCache` key present and non-empty in `config.json` |
-| 6 | Security | Extension allowlist DISABLED | Any `dxt:allowlistEnabled` key set to `"false"` in `config.json` |
-| 7 | Security | Extension blocklist is empty | `extensions-blocklist.json` exists but has 0 entries |
-| 8 | Extensions | Unsigned extension | Extension with `signatureInfo.status == "unsigned"` |
-| 9 | Extensions | Extension has dangerous tools | Extension declares `execute_javascript`, `write_file`, `edit_file`, `run_command`, or `execute_sql` |
-| 10 | Scheduled Tasks | Active scheduled task | Any task in `scheduled-tasks.json` with `enabled == true` |
-| 11 | Runtime | Sleep prevention assertion by Claude/Electron | `pmset -g assertions` output contains "Claude" or "Electron" |
-| 12 | Runtime | Claude-related crontab entry | User's `crontab -l` output contains "claude" (case-insensitive) |
-| 13 | Runtime | Claude LaunchAgent(s) found | Plist file in `~/Library/LaunchAgents/` containing "claude" in filename |
-| 14 | Runtime | Debug directory is large | `~/Library/Application Support/Claude/debug/` exceeds 100 MB |
+| 5 | Cowork Settings | Allow all browser actions ENABLED | `preferences.allowAllBrowserActions == true` |
+| 6 | Security | Cowork VM egress is UNRESTRICTED | `egressAllowedDomains == ["*"]` in any `local_*.json` session file |
+| 7 | Security | Plugin hooks executing commands | 1 or more `hooks/hooks.json` files found with command-type hooks |
+| 8 | Security | Unencrypted OAuth token in plaintext config | `oauth:tokenCache` key present and non-empty in `config.json` |
+| 9 | Security | Extension allowlist DISABLED | Any `dxt:allowlistEnabled` key set to `"false"` in `config.json` |
+| 10 | Security | Extension blocklist is empty | `extensions-blocklist.json` exists but has 0 entries |
+| 11 | Extensions | Unsigned extension | Extension with `signatureInfo.status == "unsigned"` |
+| 12 | Extensions | Extension has dangerous tools | Extension declares `execute_javascript`, `write_file`, `edit_file`, `run_command`, or `execute_sql` |
+| 13 | Scheduled Tasks | Active scheduled task | Any task in `scheduled-tasks.json` with `enabled == true` |
+| 14 | Runtime | Sleep prevention assertion by Claude/Electron | `pmset -g assertions` output contains "Claude" or "Electron" |
+| 15 | Runtime | Claude-related crontab entry | User's `crontab -l` output contains "claude" (case-insensitive) |
+| 16 | Runtime | Claude LaunchAgent(s) found | Plist file in `~/Library/LaunchAgents/` containing "claude" in filename |
+| 17 | Runtime | Debug directory is large | `~/Library/Application Support/Claude/debug/` exceeds 100 MB |
 
 ### 🔍 REVIEW Findings
 
@@ -552,9 +620,11 @@ Here is a complete catalog of every `add_finding` call in CLAUDIT, organized by 
 
 | # | Section | Finding | Trigger |
 |---|---------|---------|---------|
-| 1 | Connectors | Web connectors authenticated | 1 or more web connectors found with active OAuth connections |
-| 2 | Claude Code | Permissions granted | `permissions.allow` array is non-empty in `~/.claude/settings.json` |
-| 3 | Runtime | Claude is running | `pgrep -fl Claude` returns results |
+| 1 | Cowork Settings | Cowork VM egress restricted to specific domains | `egressAllowedDomains` is a non-`["*"]` domain list |
+| 2 | Cowork Settings | MCP tool(s) explicitly disabled | `enabledMcpTools` contains entries set to `false` |
+| 3 | Connectors | Web connectors authenticated | 1 or more web connectors found with active OAuth connections |
+| 4 | Claude Code | Permissions granted | `permissions.allow` array is non-empty in `~/.claude/settings.json` |
+| 5 | Runtime | Claude is running | `pgrep -fl Claude` returns results |
 
 ---
 
@@ -565,15 +635,17 @@ The following data is collected and displayed in the report but does **not** gen
 | Section | Data | Purpose |
 |---------|------|---------|
 | Desktop Settings | menuBarEnabled, sidebarMode, quickEntryShortcut | UX configuration context |
-| Cowork Settings | Enabled plugins, extra marketplaces, network mode | Plugin ecosystem inventory |
+| Cowork Settings | Enabled plugins, extra marketplaces, network mode, egress domain list (when restricted) | Plugin ecosystem and network inventory |
 | MCP Servers | Full server table (name, command, args, env vars) | Tool execution inventory |
 | Extensions | Full extension table (name, version, author, tools) | Extension inventory |
 | Extension Settings | Allowed directories per extension | Filesystem access scope |
 | Plugins | Installed plugins, cached plugins, marketplace availability | Plugin inventory |
+| Plugin Hooks | Full hook table (plugin, event, command) | Hook execution inventory |
 | Connectors | Desktop connectors, not-connected connectors | Integration inventory |
 | Skills | User skills, plugin skills (name, description, path) | Behavior/prompt inventory |
 | Scheduled Tasks | Disabled tasks | Historical workflow inventory |
 | App Config | Network mode, device ID (ant-did) | Configuration context |
+| Disabled MCP Tools | Per-session disabled tool list with dangerous tool callout | Tool restriction inventory |
 | Cookies | Cookie file presence | Artifact inventory |
 
 ---
@@ -590,10 +662,13 @@ CLAUDIT also builds a **Recommendations** list at the end of the report. Recomme
 6. 🔑 OAuth token is stored in plaintext
 7. 🔓 Extension allowlist is disabled
 8. 🌐 Web search is enabled
-9. 📡 Remote plugins are deployed
-10. 📦 Cached (not installed) plugins exist
-11. 🔐 Web connectors are authenticated
+9. 🌍 Allow all browser actions is enabled
+10. 🚪 Cowork VM network egress is unrestricted
+11. 🪝 Plugin hooks execute commands on lifecycle events
+12. 📡 Remote plugins are deployed
+13. 📦 Cached (not installed) plugins exist
+14. 🔐 Web connectors are authenticated
 
 ---
 
-*This document was generated for CLAUDIT-SEC v2.2.0. Last updated: 2026-03-18.*
+*This document was generated for CLAUDIT-SEC v2.2.0. Last updated: 2026-03-19.*


### PR DESCRIPTION
Add new security checks, plugin hooks collector, and fix assoc array quoting bug

   New checks:
   - allowAllBrowserActions (Browser Use toggle) — WARN if enabled
   - egressAllowedDomains from local_*.json — WARN if ["*"] (unrestricted)
   - Plugin hooks collector — scans hooks/hooks.json for shell command execution
   - enabledMcpTools disabled tools — INFO with dangerous tool callout

   Bug fix:
   - Fix zsh KSH_ARRAYS associative array quoting bug script-wide.
     Quoted key assignments (arr["$key"]=1) and unquoted reads (${arr[$key]})
     index different buckets, causing silent dedup/lookup failures.
- Fixed 15 instances across collectors and renderers. Observable fix:
     not_connected connector count dropped from 14 to 9 (5 were duplicates),
     marketplace/plugin names no longer show spurious quote marks.

   Docs updated: README, CLAUDE.md, findings-reference.md (new sections,
   renumbered TOC, updated findings tables and recommendations).