### PR TITLE
Remove False Positive OAuth Token finding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ The script follows this structure:
 ```
 ~/Library/Application Support/Claude/          # Claude Desktop dir
   claude_desktop_config.json                   # Desktop prefs + MCP servers
-  config.json                                  # App config (network mode, oauth, allowlists)
+  config.json                                  # App config (network mode, allowlists, device ID)
   extensions-installations.json                # DXT extensions
   extensions-blocklist.json                    # Extension governance
   Claude Extensions Settings/*.json            # Per-extension settings
@@ -130,7 +130,7 @@ When run as root (uid 0) — which is how MDMs like FleetDM, Jamf, Mosyle, and C
 - **Read-only** — never modifies any audited files
 - **No eval** — no dynamic code execution
 - **All variables quoted** — no word-splitting or injection vectors
-- **OAuth tokens redacted** — `[REDACTED]` in all output formats
+- **Sensitive values redacted** — `[REDACTED]` in all output formats
 - **MCP env vars** — only key names emitted, never values
 - **MCP args** — patterns matching `sk-`, `key=`, `token=`, `secret=`, `password=` are redacted
 - **HTML output** — created with `umask 077` (mode 0600)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ CLAUDIT gives you that visibility in a single command.
 | 🔗 **Connectors** | OAuth-authenticated web services, desktop integrations |
 | 🎯 **Skills** | User-created, scheduled, session-local, and plugin skills across 9 paths |
 | ⏰ **Scheduled Tasks** | Task names, cron expressions (with plain English translation) |
-| 🔐 **App Config** | OAuth token presence, network mode, extension allowlist keys |
+| 🔐 **App Config** | Network mode, extension allowlist/blocklist keys, device identifiers |
 | 🔇 **Disabled MCP Tools** | Per-session tools explicitly disabled (with dangerous tool callout) |
 | 🏃 **Runtime State** | Running processes, sleep assertions, LaunchAgents, crontab entries |
 | 🍪 **Cookies** | `Cookies` and `Cookies-journal` presence |

--- a/claude_audit.sh
+++ b/claude_audit.sh
@@ -375,12 +375,8 @@ collect_app_config() { # claude_dir
         COWORK_NETWORK_MODE="$nm"; APP_CONFIG[coworkNetworkMode]="$nm"
     fi
 
-    local has_oauth
-    has_oauth=$(printf '%s' "$data" | jq -r 'has("oauth:tokenCache") and (.["oauth:tokenCache"] | length > 0)')
-    if [[ "$has_oauth" == "true" ]]; then
-        add_finding "WARN" "Security" "Unencrypted OAuth token in plaintext config" "oauth:tokenCache present in config.json"
-        APP_CONFIG[oauth:tokenCache]="[REDACTED]"
-    fi
+    # oauth:tokenCache is encrypted via Electron safeStorage (Keychain-backed AES, v10 prefix)
+    # — standard Electron credential storage, not a security finding
 
     local dxt_keys
     dxt_keys=$(printf '%s' "$data" | jq -r 'keys[] | select(contains("dxt:allowlistEnabled"))' 2>/dev/null) || true
@@ -1185,11 +1181,6 @@ build_recommendations() {
 
     ((${#MCP_NAMES[@]} > 0)) && RECOMMENDATIONS+=("${#MCP_NAMES[@]} MCP server(s) configured — verify each is expected")
 
-    local has_oauth=false
-    for ((i=0; i<${#FINDING_MSG[@]}; i++)); do
-        [[ "${FINDING_SECT[$i]}" == "Security" && "${FINDING_SEV[$i]}" == "WARN" && "${(L)FINDING_MSG[$i]}" == *oauth* ]] && has_oauth=true
-    done
-    [[ "$has_oauth" == "true" ]] && RECOMMENDATIONS+=("OAuth token stored in plaintext config.json")
 
     local al_count=0
     for ((i=0; i<${#FINDING_MSG[@]}; i++)); do [[ "${(L)FINDING_MSG[$i]}" == *"allowlist disabled"* ]] && ((al_count++)); done
@@ -1508,10 +1499,6 @@ BANNER
 
     # Security Findings
     _section_hdr "SECURITY FINDINGS"; local found_sec=false
-    for ((i=0;i<${#FINDING_SEV[@]};i++)); do
-        [[ "${FINDING_SECT[$i]}" == "Security" && ("${(L)FINDING_MSG[$i]}" == *oauth* || "${(L)FINDING_MSG[$i]}" == *token*) ]] && {
-            echo "  $(_sev_color "${FINDING_SEV[$i]}" "[${FINDING_SEV[$i]}]") ${FINDING_MSG[$i]}"; found_sec=true; }
-    done
     for ((i=0;i<${#FINDING_SEV[@]};i++)); do
         [[ "${FINDING_SECT[$i]}" == "Security" && "${(L)FINDING_MSG[$i]}" == *allowlist* ]] && {
             echo "  $(_sev_color "${FINDING_SEV[$i]}" "[${FINDING_SEV[$i]}]") ${FINDING_MSG[$i]}"; found_sec=true; }

--- a/docs/findings-reference.md
+++ b/docs/findings-reference.md
@@ -444,15 +444,12 @@ The app config contains application-level settings including OAuth tokens, netwo
 
 ---
 
-### 🔑 Unencrypted OAuth Token in Plaintext Config
+### 🔑 OAuth Token Storage (Not Checked)
 
-- **What**: Checks whether `config.json` contains the key `oauth:tokenCache` with a non-empty value. If present, this means OAuth tokens are stored as plaintext JSON rather than in the macOS Keychain.
-- **Why it matters**:
-  - 🔴 **Risk**: Plaintext OAuth tokens can be read by any process running as the user. If the machine is compromised, the attacker gets immediate access to all OAuth-connected services without needing to crack any encryption. This is a credential storage vulnerability.
-  - 📜 **Compliance**: Storing credentials in plaintext violates most security baselines (CIS, NIST 800-53 IA-5, PCI DSS Req 8). Credentials should be stored in the system keychain or a hardware-backed credential store.
-  - 🤖 **AI enablement**: The presence of OAuth tokens indicates Claude has authenticated connections to external services.
-- **Severity**: ⚠️ `WARN` — Plaintext credential storage is a well-known security anti-pattern.
-- **Recommendation**: Report to Anthropic if this is unexpected behavior. Ensure the machine has FileVault enabled (encrypts disk at rest). Monitor for unauthorized access to the config file. The token value is automatically redacted in all CLAUDIT output formats.
+- **What**: `config.json` may contain the key `oauth:tokenCache`. CLAUDIT previously flagged this as a plaintext credential storage issue. **This check has been removed** because the value is encrypted using Electron's [`safeStorage`](https://www.electronjs.org/docs/latest/api/safe-storage) API — it is not stored in plaintext.
+- **Why it was removed**: The `oauth:tokenCache` value is prefixed with `v10` (base64: `djEw`), which is the Electron safeStorage version marker. On macOS, safeStorage encrypts data using an AES key stored in the system Keychain, protected by Claude Desktop's code signature. Only the same application running as the same user can decrypt it. This is the standard credential storage approach used by all major Electron apps (VS Code, Slack, Discord, etc.) and is not a security finding.
+- **Severity**: None — no finding is generated. The key is still redacted in JSON output as a defence-in-depth measure.
+- **Recommendation**: No action required.
 
 ---
 
@@ -578,7 +575,7 @@ CLAUDIT uses five severity levels. Here is what each means and when it is applie
 
 | Emoji | Level | Meaning | Used When |
 |-------|-------|---------|-----------|
-| ⚠️ | `WARN` | Security-relevant finding requiring review | Autonomous capabilities enabled, unsigned extensions, dangerous tools, governance controls missing, plaintext credentials, runtime anomalies |
+| ⚠️ | `WARN` | Security-relevant finding requiring review | Autonomous capabilities enabled, unsigned extensions, dangerous tools, governance controls missing, runtime anomalies |
 | 🔍 | `REVIEW` | Notable item requiring human assessment | Org-deployed remote plugins (expected but should be verified) |
 | ℹ️ | `INFO` | Informational — no action required | Processes running, permissions granted, connectors authenticated, read errors, missing directories |
 
@@ -599,16 +596,15 @@ Here is a complete catalog of every `add_finding` call in CLAUDIT, organized by 
 | 5 | Cowork Settings | Allow all browser actions ENABLED | `preferences.allowAllBrowserActions == true` |
 | 6 | Security | Cowork VM egress is UNRESTRICTED | `egressAllowedDomains == ["*"]` in any `local_*.json` session file |
 | 7 | Security | Plugin hooks executing commands | 1 or more `hooks/hooks.json` files found with command-type hooks |
-| 8 | Security | Unencrypted OAuth token in plaintext config | `oauth:tokenCache` key present and non-empty in `config.json` |
-| 9 | Security | Extension allowlist DISABLED | Any `dxt:allowlistEnabled` key set to `"false"` in `config.json` |
-| 10 | Security | Extension blocklist is empty | `extensions-blocklist.json` exists but has 0 entries |
-| 11 | Extensions | Unsigned extension | Extension with `signatureInfo.status == "unsigned"` |
-| 12 | Extensions | Extension has dangerous tools | Extension declares `execute_javascript`, `write_file`, `edit_file`, `run_command`, or `execute_sql` |
-| 13 | Scheduled Tasks | Active scheduled task | Any task in `scheduled-tasks.json` with `enabled == true` |
-| 14 | Runtime | Sleep prevention assertion by Claude/Electron | `pmset -g assertions` output contains "Claude" or "Electron" |
-| 15 | Runtime | Claude-related crontab entry | User's `crontab -l` output contains "claude" (case-insensitive) |
-| 16 | Runtime | Claude LaunchAgent(s) found | Plist file in `~/Library/LaunchAgents/` containing "claude" in filename |
-| 17 | Runtime | Debug directory is large | `~/Library/Application Support/Claude/debug/` exceeds 100 MB |
+| 8 | Security | Extension allowlist DISABLED | Any `dxt:allowlistEnabled` key set to `"false"` in `config.json` |
+| 9 | Security | Extension blocklist is empty | `extensions-blocklist.json` exists but has 0 entries |
+| 10 | Extensions | Unsigned extension | Extension with `signatureInfo.status == "unsigned"` |
+| 11 | Extensions | Extension has dangerous tools | Extension declares `execute_javascript`, `write_file`, `edit_file`, `run_command`, or `execute_sql` |
+| 12 | Scheduled Tasks | Active scheduled task | Any task in `scheduled-tasks.json` with `enabled == true` |
+| 13 | Runtime | Sleep prevention assertion by Claude/Electron | `pmset -g assertions` output contains "Claude" or "Electron" |
+| 14 | Runtime | Claude-related crontab entry | User's `crontab -l` output contains "claude" (case-insensitive) |
+| 15 | Runtime | Claude LaunchAgent(s) found | Plist file in `~/Library/LaunchAgents/` containing "claude" in filename |
+| 16 | Runtime | Debug directory is large | `~/Library/Application Support/Claude/debug/` exceeds 100 MB |
 
 ### 🔍 REVIEW Findings
 
@@ -659,15 +655,14 @@ CLAUDIT also builds a **Recommendations** list at the end of the report. Recomme
 3. ✍️ Unsigned extensions are installed
 4. ⚠️ Extensions have dangerous tools
 5. 🔌 MCP servers are configured
-6. 🔑 OAuth token is stored in plaintext
-7. 🔓 Extension allowlist is disabled
-8. 🌐 Web search is enabled
-9. 🌍 Allow all browser actions is enabled
-10. 🚪 Cowork VM network egress is unrestricted
-11. 🪝 Plugin hooks execute commands on lifecycle events
-12. 📡 Remote plugins are deployed
-13. 📦 Cached (not installed) plugins exist
-14. 🔐 Web connectors are authenticated
+6. 🔓 Extension allowlist is disabled
+7. 🌐 Web search is enabled
+8. 🌍 Allow all browser actions is enabled
+9. 🚪 Cowork VM network egress is unrestricted
+10. 🪝 Plugin hooks execute commands on lifecycle events
+11. 📡 Remote plugins are deployed
+12. 📦 Cached (not installed) plugins exist
+13. 🔐 Web connectors are authenticated
 
 ---
 


### PR DESCRIPTION
What

  Remove the oauth:tokenCache security finding from CLAUDIT. The check previously flagged this as "Unencrypted OAuth token in plaintext config" (WARN severity), but the value is actually encrypted — this was a
  false positive.

  Why

  Investigation

  The oauth:tokenCache value in config.json was assumed to be a plaintext OAuth token. Inspection of the actual value reveals it starts with djEw, which base64-decodes to v10:

  $ echo -n 'djEw' | base64 -d
  v10

  v10 is the Electron safeStorage version prefix. This confirms the value is encrypted using Electron's safeStorage.encryptString() API, not stored in plaintext.

  How Electron safeStorage works on macOS

  1. The encryption key is stored in the macOS Keychain, protected by Claude Desktop's code signature
  2. safeStorage.encryptString() produces a buffer: v10 prefix + AES-encrypted ciphertext
  3. Only the same application (matching code signature) running as the same user can call safeStorage.decryptString()
  4. macOS prompts the user if an unauthorized app tries to access the Keychain entry

  This is the standard credential storage pattern used by all major Electron apps (VS Code, Slack, Discord, etc.). Every djEw-prefixed value in config.json uses the same scheme — oauth:tokenCache and all
  dxt:allowlistCache entries.

  Why the previous finding was wrong

  ```
   ┌──────────────────────────────────────────────────┬──────────────────────────────────────────────────────────┐
  │                  Previous claim                  │                         Reality                          │
  ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────┤
  │ "Unencrypted OAuth token in plaintext config"    │ Encrypted via safeStorage (Keychain-backed AES)          │
  ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────┤
  │ "Can be read by any process running as the user" │ Ciphertext only — decryption requires Keychain access    │
  ├──────────────────────────────────────────────────┼──────────────────────────────────────────────────────────┤
  │ "Violates CIS, NIST 800-53, PCI DSS"             │ Meets credential storage requirements — uses OS keychain │
  └──────────────────────────────────────────────────┴──────────────────────────────────────────────────────────┘
```

  Decision

  Rather than downgrading to INFO, the check is removed entirely since encrypted-by-default OAuth storage is standard Electron behaviour and not a meaningful audit finding. The general-purpose JSON redaction
  filter still redacts oauth/tokenCache keys as defence-in-depth.

  Changes

  - claude_audit.sh: Removed OAuth finding from collect_app_config(), removed recommendation builder, removed ASCII renderer filter for OAuth/token findings
  - docs/findings-reference.md: Rewrote OAuth section to document removal and reasoning, removed from WARN table (renumbered 17→16 entries), removed from severity reference and recommendations list (renumbered
  14→13)
  - README.md: Updated App Config audit table row
  - CLAUDE.md: Updated config.json comment and security properties

  Testing

  - Tested terminal output (./claude_audit.sh)
  - Tested HTML output (./claude_audit.sh --html)
  - Tested JSON output (./claude_audit.sh --json)
  - Tested quiet mode (./claude_audit.sh -q)
  - No sensitive data leaked in any output format
  - Verified --json output contains no OAuth findings
  - Verified --json redaction filter still covers oauth/tokenCache keys
  - Verified ASCII "SECURITY FINDINGS" section no longer references OAuth
