### PR TITLE
Feat/workspace detection and dispatch bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ CLAUDIT gives you that visibility in a single command.
 | Area | What's Checked |
 |------|---------------|
 | 🖥️ **Desktop Settings** | `keepAwakeEnabled`, sidebar/menuBar preferences |
-| 🤖 **CoWork Settings** | Scheduled tasks, web search, browser use, network mode, egress policy, enabled plugins, marketplaces |
+| 🤖 **CoWork Settings** | Scheduled tasks, web search, browser use, dispatch (mobile→desktop), network mode, egress policy, enabled plugins, marketplaces |
+| 🏢 **Workspaces** | Multi-workspace detection, account names, session counts, org indicators (DXT-managed, org-plugins, dispatch-bridge) |
 | 🔌 **MCP Servers** | Server names, commands, arguments, environment variable keys |
 | 🧩 **Extensions (DXT)** | Installed extensions, signature status, dangerous tool grants |
 | ⚙️ **Extension Settings** | Per-extension allowed directories and configuration |
@@ -32,6 +33,7 @@ CLAUDIT gives you that visibility in a single command.
 | 🎯 **Skills** | User-created, scheduled, session-local, and plugin skills across 9 paths |
 | ⏰ **Scheduled Tasks** | Task names, cron expressions (with plain English translation) |
 | 🔐 **App Config** | Network mode, extension allowlist/blocklist keys, device identifiers |
+| 📲 **Dispatch** | Bridge state (OFF/CONFIGURED/ON), active session detection via `hostLoopMode` and `bridge-state.json` |
 | 🔇 **Disabled MCP Tools** | Per-session tools explicitly disabled (with dangerous tool callout) |
 | 🏃 **Runtime State** | Running processes, sleep assertions, LaunchAgents, crontab entries |
 | 🍪 **Cookies** | `Cookies` and `Cookies-journal` presence |

--- a/claude_audit.sh
+++ b/claude_audit.sh
@@ -46,6 +46,15 @@ EGRESS_DOMAINS=""            # most-permissive egress policy found across sessio
 EGRESS_UNRESTRICTED=false    # true if any session has ["*"]
 # Disabled MCP tools (tool keys explicitly set to false)
 DISABLED_MCP_TOOLS=()
+# Dispatch (mobile-to-desktop task assignment)
+DISPATCH_SESSION_COUNT=0     # sessions with hostLoopMode active (accepting dispatch)
+DISPATCH_ACTIVE=false        # true if any session has hostLoopMode enabled
+DISPATCH_BRIDGE_ENABLED=false  # true if bridge-state.json shows dispatch configured
+DISPATCH_BRIDGE_CONSENTED=false # true if user consented to dispatch bridge
+# Workspaces (user UUIDs under org)
+WS_UUIDS=() ; WS_ACCT_NAMES=() ; WS_EMAILS=() ; WS_SESSION_COUNTS=()
+WS_DXT_ALLOWLISTS=() ; WS_HAS_REMOTE_PLUGINS=() ; WS_BRIDGE_ACTIVE=()
+WS_ORG_UUID=""
 # Plugin hooks
 HOOK_PLUGINS=() ; HOOK_EVENTS=() ; HOOK_CMDS=()
 
@@ -368,6 +377,9 @@ collect_app_config() { # claude_dir
         return
     fi
     [[ -z "$data" || "$data" == "null" ]] && return
+
+    # Store raw for workspace detection
+    APP_CONFIG[_raw_config]="$data"
 
     local nm
     nm=$(printf '%s' "$data" | jq -r '.coworkNetworkMode // ""')
@@ -696,6 +708,120 @@ collect_plugin_hooks() { # uses SESSION_DIRS, home
         "Plugins: $(printf '%s\n' "${HOOK_PLUGINS[@]}" | sort -u | tr '\n' ',' | sed 's/,$//')"
 }
 
+collect_workspaces() { # claude_dir — enumerates user UUIDs under each org
+    local claude_dir="$1"
+    local sessions_dir="$claude_dir/local-agent-mode-sessions"
+    [[ -d "$sessions_dir" ]] || return 0
+
+    # Discover org/user pairs from directory structure
+    local org_dir
+    for org_dir in "$sessions_dir"/*/; do
+        [[ -d "$org_dir" ]] || continue
+        local org_name; org_name=$(basename "$org_dir")
+        [[ "$org_name" == .* || "$org_name" == "skills-plugin" ]] && continue
+        WS_ORG_UUID="$org_name"
+
+        local user_dir
+        for user_dir in "$org_dir"*/; do
+            [[ -d "$user_dir" ]] || continue
+            local uid; uid=$(basename "$user_dir")
+            [[ "$uid" == .* ]] && continue
+
+            WS_UUIDS+=("$uid")
+
+            # Count session files
+            local sc=0; local _e
+            for _e in "$user_dir"/local_*.json; do [[ -f "$_e" ]] && ((sc++)); done
+            WS_SESSION_COUNTS+=("$sc")
+
+            # Get account name/email from first session file with data
+            local acct="" email=""
+            for _e in "$user_dir"/local_*.json; do
+                [[ -f "$_e" ]] || continue
+                local _pair
+                _pair=$(jq -r '[(.accountName // ""), (.emailAddress // "")] | join("\t")' "$_e" 2>/dev/null) || continue
+                local _a="${_pair%%	*}" _em="${_pair#*	}"
+                if [[ -n "$_a" && "$_a" != "null" ]]; then acct="$_a"; email="${_em:-}"; break; fi
+            done
+            WS_ACCT_NAMES+=("$acct")
+            [[ "$email" == "null" ]] && email=""
+            WS_EMAILS+=("$email")
+
+            # DXT allowlist enabled for this user UUID (from config.json)
+            local dxt_val
+            dxt_val=$(printf '%s' "${APP_CONFIG[_raw_config]:-"{}"}" | jq -r --arg k "dxt:allowlistEnabled:$uid" '.[$k] // "unset"' 2>/dev/null) || true
+            WS_DXT_ALLOWLISTS+=("$dxt_val")
+
+            # Has remote_cowork_plugins directory (Teams/Enterprise indicator)
+            if [[ -d "$user_dir/remote_cowork_plugins" ]]; then
+                WS_HAS_REMOTE_PLUGINS+=(true)
+            else
+                WS_HAS_REMOTE_PLUGINS+=(false)
+            fi
+
+            # Bridge active for this user
+            WS_BRIDGE_ACTIVE+=(false)  # updated by collect_bridge below
+        done
+    done
+
+    # Also check config.json for user UUIDs with DXT entries but no session dir
+    local config_path="$claude_dir/config.json"
+    if [[ -f "$config_path" ]]; then
+        local dxt_uids
+        dxt_uids=$(jq -r 'keys[] | select(startswith("dxt:allowlistEnabled:")) | split(":")[2]' "$config_path" 2>/dev/null) || true
+        while IFS= read -r duid; do
+            [[ -z "$duid" ]] && continue
+            # Check if already found
+            local found=false; local wi
+            for ((wi=0; wi<${#WS_UUIDS[@]}; wi++)); do [[ "${WS_UUIDS[$wi]}" == "$duid" ]] && { found=true; break; }; done
+            [[ "$found" == "false" ]] && {
+                WS_UUIDS+=("$duid"); WS_SESSION_COUNTS+=(0); WS_ACCT_NAMES+=(""); WS_EMAILS+=("")
+                local dxt_v; dxt_v=$(jq -r --arg k "dxt:allowlistEnabled:$duid" '.[$k] // "unset"' "$config_path" 2>/dev/null) || true
+                WS_DXT_ALLOWLISTS+=("$dxt_v")
+                # Check if session dir exists for this UUID under known org
+                if [[ -n "$WS_ORG_UUID" && -d "$sessions_dir/$WS_ORG_UUID/$duid/remote_cowork_plugins" ]]; then
+                    WS_HAS_REMOTE_PLUGINS+=(true)
+                else
+                    WS_HAS_REMOTE_PLUGINS+=(false)
+                fi
+                WS_BRIDGE_ACTIVE+=(false)
+            }
+        done <<< "$dxt_uids"
+    fi
+
+    # Bridge-state.json for dispatch detection
+    local bridge_path="$claude_dir/bridge-state.json"
+    if [[ -f "$bridge_path" ]]; then
+        local bridge_data
+        bridge_data=$(safe_read_json "$bridge_path") || true
+        if [[ -z "$JSON_ERROR" && -n "$bridge_data" && "$bridge_data" != "null" ]]; then
+            # Each key is "userUUID:orgUUID"
+            local bridge_keys
+            bridge_keys=$(printf '%s' "$bridge_data" | jq -r 'keys[]' 2>/dev/null) || true
+            while IFS= read -r bk; do
+                [[ -z "$bk" ]] && continue
+                local b_uid="${bk%%:*}"
+                local b_enabled b_consented
+                b_enabled=$(printf '%s' "$bridge_data" | jq -r --arg k "$bk" '.[$k].enabled // false')
+                b_consented=$(printf '%s' "$bridge_data" | jq -r --arg k "$bk" '.[$k].userConsented // false')
+                [[ "$b_enabled" == "true" ]] && DISPATCH_BRIDGE_ENABLED=true
+                [[ "$b_consented" == "true" ]] && DISPATCH_BRIDGE_CONSENTED=true
+                # Mark bridge active for matching workspace
+                local wi
+                for ((wi=0; wi<${#WS_UUIDS[@]}; wi++)); do
+                    [[ "${WS_UUIDS[$wi]}" == "$b_uid" ]] && WS_BRIDGE_ACTIVE[$wi]=true
+                done
+            done <<< "$bridge_keys"
+        fi
+    fi
+
+    # Workspace findings
+    ((${#WS_UUIDS[@]} > 1)) && add_finding "INFO" "Workspaces" "${#WS_UUIDS[@]} workspace(s) detected in Claude Desktop" "org=$WS_ORG_UUID"
+    if [[ "$DISPATCH_BRIDGE_ENABLED" == "true" ]]; then
+        add_finding "WARN" "Cowork Settings" "Dispatch bridge is CONFIGURED — mobile device can dispatch tasks to this desktop" "bridge-state.json: enabled=true, userConsented=$DISPATCH_BRIDGE_CONSENTED"
+    fi
+}
+
 collect_connectors() { # uses SESSION_DIRS, EXT_*, MCP_*
     local -A best_ts best_conn_json
     local sess_dir
@@ -725,6 +851,11 @@ collect_connectors() { # uses SESSION_DIRS, EXT_*, MCP_*
                 for ((di=0; di<${#DISABLED_MCP_TOOLS[@]}; di++)); do [[ "${DISABLED_MCP_TOOLS[$di]}" == "$dk" ]] && { already=true; break; }; done
                 [[ "$already" == "false" ]] && DISABLED_MCP_TOOLS+=("$dk")
             done <<< "$disabled"
+
+            # Dispatch detection (mobile-to-desktop task assignment)
+            local hlm
+            hlm=$(printf '%s' "$data" | jq -r '.hostLoopMode // "null"')
+            [[ "$hlm" == "true" ]] && { DISPATCH_ACTIVE=true; ((DISPATCH_SESSION_COUNT++)); }
 
             local ts rmc_len
             ts=$(printf '%s' "$data" | jq -r '.lastActivityAt // 0')
@@ -827,6 +958,11 @@ collect_connectors() { # uses SESSION_DIRS, EXT_*, MCP_*
         fi
     done
     ((${#DISABLED_MCP_TOOLS[@]} > 0)) && add_finding "INFO" "Cowork Settings" "${#DISABLED_MCP_TOOLS[@]} MCP tool(s) explicitly disabled" "${disabled_dangerous:+Includes dangerous tools: $disabled_dangerous}"
+
+    # Dispatch findings (hostLoopMode = actively accepting; bridge = configured)
+    if [[ "$DISPATCH_ACTIVE" == "true" ]]; then
+        add_finding "WARN" "Cowork Settings" "Dispatch is actively ACCEPTING tasks — phone is remotely triggering desktop tasks" "hostLoopMode=true (${DISPATCH_SESSION_COUNT} session(s))"
+    fi
 }
 
 collect_skills() { # uses SESSION_DIRS, home
@@ -1194,6 +1330,11 @@ build_recommendations() {
     [[ "$EGRESS_UNRESTRICTED" == "true" ]] && \
         RECOMMENDATIONS+=("Cowork VM network egress is unrestricted — all domains reachable")
 
+    [[ "$DISPATCH_ACTIVE" == "true" ]] && \
+        RECOMMENDATIONS+=("Dispatch is actively accepting tasks — mobile device is remotely triggering tasks on this desktop")
+    [[ "$DISPATCH_BRIDGE_ENABLED" == "true" && "$DISPATCH_ACTIVE" != "true" ]] && \
+        RECOMMENDATIONS+=("Dispatch bridge is configured — mobile device can dispatch tasks to this desktop (files, connectors, computer use)")
+
     ((${#HOOK_PLUGINS[@]} > 0)) && \
         RECOMMENDATIONS+=("${#HOOK_PLUGINS[@]} plugin hook(s) execute commands on lifecycle events — review for data exfiltration risk")
 
@@ -1232,7 +1373,7 @@ _sev_color() {
     case "$s" in CRITICAL) _red "$t";; WARN|REVIEW) _yellow "$t";; INFO) _cyan "$t";; OK|PASS) _green "$t";; *) printf '%s' "$t";; esac
 }
 _on_off() {
-    case "$1" in true) _yellow "ON";; false) _green "OFF";; "") _dim "-";; *) printf '%s' "$1";; esac
+    case "$1" in true) _yellow "ON";; false) _green "OFF";; configured) _yellow "CONFIGURED";; "") _dim "-";; *) printf '%s' "$1";; esac
 }
 
 _strip_ansi() { sed $'s/\033\\[[0-9;]*m//g' <<< "$1"; }
@@ -1306,7 +1447,28 @@ BANNER
     for ((i=0;i<${#FINDING_SEV[@]};i++)); do [[ "${FINDING_SEV[$i]}" == "WARN" ]] && ((warn_c++)); [[ "${FINDING_SEV[$i]}" == "REVIEW" ]] && ((rev_c++)); done
     echo "  Scheduled tasks: ${#ST_IDS[@]}  |  MCP servers: ${#MCP_NAMES[@]}  |  Extensions: ${#EXT_NAMES[@]}"
     echo "  Plugins: $n_inst installed, $n_rem remote, $n_cach cached  |  Connectors: $n_web web, $n_nc not connected"
-    echo "  Skills: ${#SK_NAMES[@]}  |  Findings: $warn_c warnings, $rev_c items to review"; echo
+    echo "  Skills: ${#SK_NAMES[@]}  |  Findings: $warn_c warnings, $rev_c items to review"
+    ((${#WS_UUIDS[@]} > 0)) && echo "  Workspaces: ${#WS_UUIDS[@]}  |  Dispatch bridge: $([[ "$DISPATCH_BRIDGE_ENABLED" == "true" ]] && echo "CONFIGURED" || echo "off")"
+    echo
+
+    # Workspaces
+    if ((${#WS_UUIDS[@]} > 1)); then
+        if [[ "$quiet" != "true" ]]; then
+            _section_hdr "WORKSPACES"
+            local rows=""
+            for ((i=0; i<${#WS_UUIDS[@]}; i++)); do
+                [[ -n "$rows" ]] && rows+=$'\n'
+                local uid_short="${WS_UUIDS[$i]:0:8}..."
+                local indicators=""
+                [[ "${WS_DXT_ALLOWLISTS[$i]}" == "true" ]] && indicators="DXT-managed"
+                [[ "${WS_HAS_REMOTE_PLUGINS[$i]}" == "true" ]] && { [[ -n "$indicators" ]] && indicators+=", "; indicators+="org-plugins"; }
+                [[ "${WS_BRIDGE_ACTIVE[$i]}" == "true" ]] && { [[ -n "$indicators" ]] && indicators+=", "; indicators+="dispatch-bridge"; }
+                [[ -z "$indicators" ]] && indicators="-"
+                rows+="$uid_short|${WS_ACCT_NAMES[$i]:-$(_dim "-")}|${WS_EMAILS[$i]:-$(_dim "-")}|${WS_SESSION_COUNTS[$i]}|$indicators"
+            done
+            ascii_table "User UUID|Account|Email|Sessions|Indicators" "$rows" "14|10|26|8|24"; echo
+        fi
+    fi
 
     # Desktop Settings
     local kae="${DESKTOP_PREFS[keepAwakeEnabled]:-false}"
@@ -1329,6 +1491,13 @@ BANNER
         printf '  ccdScheduledTasksEnabled:      %s' "$(_on_off "$ccd")"; [[ "$ccd" == "true" ]] && printf '   ⚠ Code Desktop scheduled tasks'; echo
         printf '  webSearchEnabled:              %s' "$(_on_off "$cws")"; [[ "$cws" == "true" ]] && printf '   ⚠ Autonomous internet access'; echo
         printf '  allowAllBrowserActions:        %s' "$(_on_off "$aba")"; [[ "$aba" == "true" ]] && printf '   ⚠ Browse any website without asking'; echo
+        local dispatch_state="false"
+        [[ "$DISPATCH_BRIDGE_ENABLED" == "true" ]] && dispatch_state="configured"
+        [[ "$DISPATCH_ACTIVE" == "true" ]] && dispatch_state="true"
+        printf '  dispatch (mobile→desktop):    %s' "$(_on_off "$dispatch_state")"
+        if [[ "$DISPATCH_ACTIVE" == "true" ]]; then printf '   ⚠ Actively accepting dispatched tasks'
+        elif [[ "$DISPATCH_BRIDGE_ENABLED" == "true" ]]; then printf '   ⚠ Bridge configured — phone can dispatch tasks'
+        fi; echo
         printf '  networkMode:                   %s\n' "${COWORK_NETWORK_MODE:-$(_dim "-")}"
         if [[ "$EGRESS_UNRESTRICTED" == "true" ]]; then
             printf '  egressAllowedDomains:          %s   ⚠ All domains reachable\n' "$(_on_off true)"
@@ -1350,6 +1519,8 @@ BANNER
         [[ "$ccd" == "true" ]] && wi+=("$(printf '  ccdScheduledTasksEnabled:      %s   ⚠ Code Desktop scheduled tasks' "$(_on_off "$ccd")")")
         [[ "$cws" == "true" ]] && wi+=("$(printf '  webSearchEnabled:              %s   ⚠ Autonomous internet access' "$(_on_off "$cws")")")
         [[ "$aba" == "true" ]] && wi+=("$(printf '  allowAllBrowserActions:        %s   ⚠ Browse any website without asking' "$(_on_off "$aba")")")
+        [[ "$DISPATCH_ACTIVE" == "true" ]] && wi+=("$(printf '  dispatch (mobile→desktop):    %s   ⚠ Actively accepting dispatched tasks' "$(_on_off true)")")
+        [[ "$DISPATCH_BRIDGE_ENABLED" == "true" && "$DISPATCH_ACTIVE" != "true" ]] && wi+=("$(printf '  dispatch (mobile→desktop):    %s   ⚠ Bridge configured — phone can dispatch tasks' "$(_on_off "configured")")")
         [[ "$EGRESS_UNRESTRICTED" == "true" ]] && wi+=("$(printf '  egressAllowedDomains:          %s   ⚠ All domains reachable' "$(_on_off true)")")
         if ((${#wi[@]}>0)); then _section_hdr "COWORK SETTINGS"; for w in "${wi[@]}"; do echo "$w"; done; echo; fi
     fi
@@ -1529,6 +1700,7 @@ _badge_html() {
 }
 _on_off_html() {
     case "$1" in true) echo '<span style="color:#ffc107;font-weight:600">ON</span>';; false) echo '<span style="color:#28a745">OFF</span>';;
+        configured) echo '<span style="color:#ffc107;font-weight:600">CONFIGURED</span>';;
         "") echo '<span style="color:#666">-</span>';; *) _h "$1";; esac
 }
 
@@ -1570,8 +1742,25 @@ code{background:rgba(233,69,96,0.15);padding:2px 6px;border-radius:3px;font-size
 <div>Scheduled tasks: <strong>${#ST_IDS[@]}</strong> &bull; MCP servers: <strong>${#MCP_NAMES[@]}</strong> &bull; Extensions: <strong>${#EXT_NAMES[@]}</strong></div>
 <div>Plugins: <strong>${n_inst}</strong> installed, <strong>${n_rem}</strong> remote, <strong>${n_cach}</strong> cached &bull; Connectors: <strong>${n_web}</strong> web, <strong>${n_nc}</strong> not connected &bull; Skills: <strong>${#SK_NAMES[@]}</strong></div>
 <div style="margin-top:5px;">$(_badge_html "WARN") ${warn_c} warnings &nbsp; $(_badge_html "REVIEW") ${rev_c} items to review</div>
+$( ((${#WS_UUIDS[@]} > 0)) && echo "<div>Workspaces: <strong>${#WS_UUIDS[@]}</strong> &bull; Dispatch bridge: <strong>$([[ "$DISPATCH_BRIDGE_ENABLED" == "true" ]] && echo "CONFIGURED" || echo "off")</strong></div>" )
 </div>
 HTMLEOF
+
+    # Workspaces
+    if ((${#WS_UUIDS[@]} > 1)) && [[ "$quiet" != "true" ]]; then
+        echo '<details open><summary>Workspaces</summary><div class="detail-content">'
+        echo '<table><tr><th>User UUID</th><th>Account</th><th>Email</th><th>Sessions</th><th>Indicators</th></tr>'
+        for ((i=0; i<${#WS_UUIDS[@]}; i++)); do
+            local html_ind=""
+            [[ "${WS_DXT_ALLOWLISTS[$i]}" == "true" ]] && html_ind="DXT-managed"
+            [[ "${WS_HAS_REMOTE_PLUGINS[$i]}" == "true" ]] && { [[ -n "$html_ind" ]] && html_ind+=", "; html_ind+="org-plugins"; }
+            [[ "${WS_BRIDGE_ACTIVE[$i]}" == "true" ]] && { [[ -n "$html_ind" ]] && html_ind+=", "; html_ind+="dispatch-bridge"; }
+            [[ -z "$html_ind" ]] && html_ind="-"
+            printf '<tr><td><code>%s...</code></td><td>%s</td><td>%s</td><td>%s</td><td>%s</td></tr>\n' \
+                "$(_h "${WS_UUIDS[$i]:0:8}")" "$(_h "${WS_ACCT_NAMES[$i]:-"-"}")" "$(_h "${WS_EMAILS[$i]:-"-"}")" "${WS_SESSION_COUNTS[$i]}" "$(_h "$html_ind")"
+        done
+        echo '</table></div></details>'
+    fi
 
     # Desktop Settings
     local kae="${DESKTOP_PREFS[keepAwakeEnabled]:-false}"
@@ -1600,6 +1789,13 @@ HTMLEOF
             printf '<div class="setting-row"><span class="setting-key">%s</span><span class="setting-val">%s</span>' "$(_h "$label")" "$(_on_off_html "$val")"
             [[ "$val" == "true" ]] && printf '<span class="setting-warn">&#9888; %s</span>' "$(_h "$wmsg")"; echo '</div>'
         done
+        local html_dispatch_state="false"
+        [[ "$DISPATCH_BRIDGE_ENABLED" == "true" ]] && html_dispatch_state="configured"
+        [[ "$DISPATCH_ACTIVE" == "true" ]] && html_dispatch_state="true"
+        printf '<div class="setting-row"><span class="setting-key">dispatch (mobile&#8594;desktop)</span><span class="setting-val">%s</span>' "$(_on_off_html "$html_dispatch_state")"
+        if [[ "$DISPATCH_ACTIVE" == "true" ]]; then printf '<span class="setting-warn">&#9888; Actively accepting dispatched tasks</span>'
+        elif [[ "$DISPATCH_BRIDGE_ENABLED" == "true" ]]; then printf '<span class="setting-warn">&#9888; Bridge configured — phone can dispatch tasks</span>'
+        fi; echo '</div>'
         printf '<div class="setting-row"><span class="setting-key">networkMode</span><span class="setting-val">%s</span></div>\n' "$(_h "${COWORK_NETWORK_MODE:-"-"}")"
         if [[ "$EGRESS_UNRESTRICTED" == "true" ]]; then
             printf '<div class="setting-row"><span class="setting-key">egressAllowedDomains</span><span class="setting-val">%s</span><span class="setting-warn">&#9888; All domains reachable</span></div>\n' "$(_on_off_html true)"
@@ -1610,7 +1806,7 @@ HTMLEOF
         ((${#COWORK_ENABLED_PLUGINS[@]}>0)) && printf '<div class="setting-row"><span class="setting-key">Enabled plugins</span><span class="setting-val">%s</span></div>\n' "$(_h "$(IFS=', '; echo "${COWORK_ENABLED_PLUGINS[*]}")")"
         echo '</div></details>'
     else
-        if [[ "$cst" == "true" || "$ccd" == "true" || "$cws" == "true" || "$aba" == "true" || "$EGRESS_UNRESTRICTED" == "true" ]]; then
+        if [[ "$cst" == "true" || "$ccd" == "true" || "$cws" == "true" || "$aba" == "true" || "$DISPATCH_ACTIVE" == "true" || "$DISPATCH_BRIDGE_ENABLED" == "true" || "$EGRESS_UNRESTRICTED" == "true" ]]; then
             echo '<details open><summary>Cowork Settings</summary><div class="detail-content">'
             for tuple in "coworkScheduledTasksEnabled|scheduledTasksEnabled|Autonomous task execution" \
                          "ccdScheduledTasksEnabled|ccdScheduledTasksEnabled|Code Desktop scheduled tasks" \
@@ -1619,6 +1815,8 @@ HTMLEOF
                 IFS='|' read -r key label wmsg <<< "$tuple"
                 [[ "${COWORK_PREFS[$key]:-false}" == "true" ]] && printf '<div class="setting-row"><span class="setting-key">%s</span><span class="setting-val">%s</span><span class="setting-warn">&#9888; %s</span></div>\n' "$(_h "$label")" "$(_on_off_html true)" "$(_h "$wmsg")"
             done
+            [[ "$DISPATCH_ACTIVE" == "true" ]] && printf '<div class="setting-row"><span class="setting-key">dispatch (mobile&#8594;desktop)</span><span class="setting-val">%s</span><span class="setting-warn">&#9888; Actively accepting dispatched tasks</span></div>\n' "$(_on_off_html true)"
+            [[ "$DISPATCH_BRIDGE_ENABLED" == "true" && "$DISPATCH_ACTIVE" != "true" ]] && printf '<div class="setting-row"><span class="setting-key">dispatch (mobile&#8594;desktop)</span><span class="setting-val">%s</span><span class="setting-warn">&#9888; Bridge configured — phone can dispatch tasks</span></div>\n' "$(_on_off_html configured)"
             [[ "$EGRESS_UNRESTRICTED" == "true" ]] && printf '<div class="setting-row"><span class="setting-key">egressAllowedDomains</span><span class="setting-val">%s</span><span class="setting-warn">&#9888; All domains reachable</span></div>\n' "$(_on_off_html true)"
             echo '</div></details>'
         fi
@@ -1807,7 +2005,12 @@ render_json() {
     done; ext_j+="]"
 
     local dp_j="{\"keepAwakeEnabled\":${DESKTOP_PREFS[keepAwakeEnabled]:-false},\"menuBarEnabled\":${DESKTOP_PREFS[menuBarEnabled]:-false}}"
-    local cp_j="{\"coworkScheduledTasksEnabled\":${COWORK_PREFS[coworkScheduledTasksEnabled]:-false},\"ccdScheduledTasksEnabled\":${COWORK_PREFS[ccdScheduledTasksEnabled]:-false},\"coworkWebSearchEnabled\":${COWORK_PREFS[coworkWebSearchEnabled]:-false},\"allowAllBrowserActions\":${COWORK_PREFS[allowAllBrowserActions]:-false}}"
+    local cp_j="{\"coworkScheduledTasksEnabled\":${COWORK_PREFS[coworkScheduledTasksEnabled]:-false},\"ccdScheduledTasksEnabled\":${COWORK_PREFS[ccdScheduledTasksEnabled]:-false},\"coworkWebSearchEnabled\":${COWORK_PREFS[coworkWebSearchEnabled]:-false},\"allowAllBrowserActions\":${COWORK_PREFS[allowAllBrowserActions]:-false},\"dispatchActive\":${DISPATCH_ACTIVE},\"dispatchSessionCount\":${DISPATCH_SESSION_COUNT},\"dispatchBridgeEnabled\":${DISPATCH_BRIDGE_ENABLED},\"dispatchBridgeConsented\":${DISPATCH_BRIDGE_CONSENTED}}"
+
+    local ws_j="["; for ((i=0;i<${#WS_UUIDS[@]};i++)); do ((i>0)) && ws_j+=","
+        local ws_dxt="${WS_DXT_ALLOWLISTS[$i]:-false}"; [[ "$ws_dxt" != "true" ]] && ws_dxt="false"
+        ws_j+="{\"userUuid\":$(_jstr "${WS_UUIDS[$i]}"),\"accountName\":$(_jstr "${WS_ACCT_NAMES[$i]}"),\"email\":$(_jstr "${WS_EMAILS[$i]}"),\"sessionCount\":${WS_SESSION_COUNTS[$i]:-0},\"dxtAllowlistEnabled\":${ws_dxt},\"hasRemotePlugins\":${WS_HAS_REMOTE_PLUGINS[$i]:-false},\"bridgeActive\":${WS_BRIDGE_ACTIVE[$i]:-false}}"
+    done; ws_j+="]"
 
     local egress_j
     if [[ "$EGRESS_UNRESTRICTED" == "true" ]]; then egress_j='["*"]'
@@ -1826,12 +2029,13 @@ render_json() {
         hook_j+="{\"plugin\":$(_jstr "${HOOK_PLUGINS[$i]}"),\"event\":$(_jstr "${HOOK_EVENTS[$i]}"),\"command\":$(_jstr "${HOOK_CMDS[$i]}")}"
     done; hook_j+="]"
 
-    printf '{"timestamp":%s,"hostname":%s,"username":%s,"home_dir":%s,"findings":%s,"desktop_prefs":%s,"cowork_prefs":%s,"cowork_network_mode":%s,"egress_allowed_domains":%s,"disabled_mcp_tools":%s,"plugin_hooks":%s,"mcp_servers":%s,"plugins":%s,"connectors":%s,"skills":%s,"scheduled_tasks":%s,"extensions":%s,"blocklist_entries":%d,"blocklist_status":%s,"claude_code_settings":%s,"warn_count":%d,"info_count":%d}' \
+    printf '{"timestamp":%s,"hostname":%s,"username":%s,"home_dir":%s,"findings":%s,"desktop_prefs":%s,"cowork_prefs":%s,"cowork_network_mode":%s,"egress_allowed_domains":%s,"disabled_mcp_tools":%s,"plugin_hooks":%s,"mcp_servers":%s,"plugins":%s,"connectors":%s,"skills":%s,"scheduled_tasks":%s,"extensions":%s,"blocklist_entries":%d,"blocklist_status":%s,"claude_code_settings":%s,"workspaces":%s,"org_uuid":%s,"warn_count":%d,"info_count":%d}' \
         "$(_jstr "$TIMESTAMP")" "$(_jstr "$HOSTNAME_VAL")" "$(_jstr "$AUDIT_USER")" "$(_jstr "$HOME_DIR")" \
         "$findings_j" "$dp_j" "$cp_j" "$(_jstr "$COWORK_NETWORK_MODE")" \
         "$egress_j" "$dtool_j" "$hook_j" \
         "$mcp_j" "$plg_j" "$conn_j" "$sk_j" "$st_j" "$ext_j" \
         "$BLOCKLIST_ENTRIES" "$(_jstr "$BLOCKLIST_STATUS")" "$CLAUDE_CODE_JSON" \
+        "$ws_j" "$(_jstr "$WS_ORG_UUID")" \
         "$WARN_COUNT" "$INFO_COUNT" | \
     jq 'def redact_val: if type=="string" and test("(sk-[a-zA-Z0-9]{20,}|://[^@\\s]+@)";"x") then "[REDACTED]" else . end; def redact: if type=="object" then to_entries|map(if .key|test("oauth|token|tokenCache|secret|password|credential|apiKey|api_key|access_token|refresh_token|private_key|privateKey";"i") then .value="[REDACTED]" else .value=(.value|redact) end)|from_entries elif type=="array" then map(redact) elif type=="string" then redact_val else . end; redact'
 }
@@ -1850,6 +2054,10 @@ run_audit() {
     PLG_IDS=(); PLG_SKILL_COUNTS=(); MARKETPLACE_AVAILABLE=()
     CONN_NAMES=(); CONN_CATS=(); CONN_TOOLS=(); CONN_TAGS=()
     EGRESS_DOMAINS=""; EGRESS_UNRESTRICTED=false; DISABLED_MCP_TOOLS=()
+    DISPATCH_SESSION_COUNT=0; DISPATCH_ACTIVE=false
+    DISPATCH_BRIDGE_ENABLED=false; DISPATCH_BRIDGE_CONSENTED=false
+    WS_UUIDS=(); WS_ACCT_NAMES=(); WS_EMAILS=(); WS_SESSION_COUNTS=()
+    WS_DXT_ALLOWLISTS=(); WS_HAS_REMOTE_PLUGINS=(); WS_BRIDGE_ACTIVE=(); WS_ORG_UUID=""
     HOOK_PLUGINS=(); HOOK_EVENTS=(); HOOK_CMDS=()
     SK_NAMES=(); SK_DESCS=(); SK_SRCS=(); SK_PLUGINS=(); SK_PATHS=()
     ST_IDS=(); ST_CRONS=(); ST_CRON_ENG=(); ST_ENABLEDS=(); ST_FPATHS=()
@@ -1873,6 +2081,7 @@ run_audit() {
     collect_plugins
     collect_plugin_hooks "$home"
     collect_connectors
+    collect_workspaces "$claude_dir"
     collect_skills "$home"
     collect_scheduled_tasks
     collect_blocklist "$claude_dir"

--- a/claude_audit.sh
+++ b/claude_audit.sh
@@ -1671,16 +1671,8 @@ BANNER
     # Security Findings
     _section_hdr "SECURITY FINDINGS"; local found_sec=false
     for ((i=0;i<${#FINDING_SEV[@]};i++)); do
-        [[ "${FINDING_SECT[$i]}" == "Security" && "${(L)FINDING_MSG[$i]}" == *allowlist* ]] && {
-            echo "  $(_sev_color "${FINDING_SEV[$i]}" "[${FINDING_SEV[$i]}]") ${FINDING_MSG[$i]}"; found_sec=true; }
-    done
-    for ((i=0;i<${#FINDING_SEV[@]};i++)); do
-        [[ "${FINDING_SECT[$i]}" == "Security" && "${(L)FINDING_MSG[$i]}" == *blocklist* ]] && {
-            echo "  $(_sev_color "${FINDING_SEV[$i]}" "[${FINDING_SEV[$i]}]") ${FINDING_MSG[$i]}"; found_sec=true; }
-    done
-    for ((i=0;i<${#FINDING_SEV[@]};i++)); do
-        [[ "${FINDING_SECT[$i]}" == "Runtime" && "${FINDING_SEV[$i]}" != "INFO" && "${FINDING_SEV[$i]}" != "OK" ]] && {
-            echo "  $(_sev_color "${FINDING_SEV[$i]}" "[${FINDING_SEV[$i]}]") ${FINDING_MSG[$i]}"; found_sec=true; }
+        [[ "${FINDING_SEV[$i]}" == "WARN" ]] && {
+            echo "  $(_sev_color "WARN" "[WARN]") ${FINDING_MSG[$i]}"; found_sec=true; }
     done
     [[ "$found_sec" == "true" ]] || echo "  $(_green 'No security issues detected.')"; echo
 
@@ -1944,13 +1936,8 @@ HTMLEOF
     echo '<details open><summary>Security Findings</summary><div class="detail-content">'
     local fany=false
     for ((i=0;i<${#FINDING_SEV[@]};i++)); do
-        [[ "${FINDING_SECT[$i]}" != "Security" ]] && continue
-        [[ "$quiet" == "true" && "${FINDING_SEV[$i]}" != "CRITICAL" && "${FINDING_SEV[$i]}" != "WARN" ]] && continue
-        printf '<div class="finding">%s %s</div>\n' "$(_badge_html "${FINDING_SEV[$i]}")" "$(_h "${FINDING_MSG[$i]}")"; fany=true
-    done
-    for ((i=0;i<${#FINDING_SEV[@]};i++)); do
-        [[ "${FINDING_SECT[$i]}" == "Runtime" && "${FINDING_SEV[$i]}" != "INFO" && "${FINDING_SEV[$i]}" != "OK" ]] && {
-            printf '<div class="finding">%s %s</div>\n' "$(_badge_html "${FINDING_SEV[$i]}")" "$(_h "${FINDING_MSG[$i]}")"; fany=true; }
+        [[ "${FINDING_SEV[$i]}" != "WARN" ]] && continue
+        printf '<div class="finding">%s %s</div>\n' "$(_badge_html "WARN")" "$(_h "${FINDING_MSG[$i]}")"; fany=true
     done
     [[ "$fany" == "true" ]] || echo '<p style="color:#28a745">No security issues detected.</p>'; echo '</div></details>'
 

--- a/docs/findings-reference.md
+++ b/docs/findings-reference.md
@@ -1,6 +1,6 @@
 # 📋 CLAUDIT-SEC Findings Reference
 
-> **A comprehensive reference for every check performed by CLAUDIT-SEC v2.2.0**
+> **A comprehensive reference for every check performed by CLAUDIT-SEC v2.3.0**
 >
 > This document is intended for security teams, compliance reviewers, and administrators who need to understand exactly what CLAUDIT inspects, why each check matters, and how to respond when findings are flagged.
 
@@ -10,20 +10,22 @@
 
 1. [🖥️ Desktop Settings](#1--desktop-settings)
 2. [🤖 Cowork Settings](#2--cowork-settings)
-3. [🔌 MCP Servers](#3--mcp-servers)
-4. [🧩 Extensions (DXT)](#4--extensions-dxt)
-5. [📂 Extension Settings](#5--extension-settings)
-6. [🛡️ Extension Governance (Blocklist & Allowlist)](#6--extension-governance-blocklist--allowlist)
-7. [🔗 Plugins](#7--plugins)
-8. [🪝 Plugin Hooks](#8--plugin-hooks)
-9. [🌐 Connectors](#9--connectors)
-10. [🎯 Skills](#10--skills)
-11. [⏰ Scheduled Tasks](#11--scheduled-tasks)
-12. [⚙️ App Config (config.json)](#12--app-config-configjson)
-13. [💻 Claude Code Settings](#13--claude-code-settings)
-14. [🏃 Runtime State](#14--runtime-state)
-15. [🍪 Cookies](#15--cookies)
-16. [📊 Severity Level Reference](#16--severity-level-reference)
+3. [📲 Dispatch](#3--dispatch)
+4. [🏢 Workspaces](#4--workspaces)
+5. [🔌 MCP Servers](#5--mcp-servers)
+6. [🧩 Extensions (DXT)](#6--extensions-dxt)
+7. [📂 Extension Settings](#7--extension-settings)
+8. [🛡️ Extension Governance (Blocklist & Allowlist)](#8--extension-governance-blocklist--allowlist)
+9. [🔗 Plugins](#9--plugins)
+10. [🪝 Plugin Hooks](#10--plugin-hooks)
+11. [🌐 Connectors](#11--connectors)
+12. [🎯 Skills](#12--skills)
+13. [⏰ Scheduled Tasks](#13--scheduled-tasks)
+14. [⚙️ App Config (config.json)](#14--app-config-configjson)
+15. [💻 Claude Code Settings](#15--claude-code-settings)
+16. [🏃 Runtime State](#16--runtime-state)
+17. [🍪 Cookies](#17--cookies)
+18. [📊 Severity Level Reference](#18--severity-level-reference)
 
 ---
 
@@ -161,7 +163,91 @@ Cowork is Claude Desktop's agentic mode. These checks examine settings that cont
 
 ---
 
-## 3. 🔌 MCP Servers
+## 3. 📲 Dispatch
+
+**Source files:** `bridge-state.json`, `local_*.json` (session files) → `hostLoopMode`
+
+Dispatch is Claude Desktop's mobile-to-desktop task assignment feature. It allows a user's phone to remotely trigger tasks on their desktop machine. CLAUDIT detects dispatch state from two sources: the bridge configuration file and active session state.
+
+---
+
+### 🌉 Dispatch Bridge Configured
+
+- **What**: Reads `bridge-state.json` at the root of the Claude Desktop data directory. Each key is a `userUUID:orgUUID` pair with `enabled` and `userConsented` boolean fields. If any entry has `enabled: true`, this finding is generated.
+- **Why it matters**:
+  - 🔴 **Risk**: When the dispatch bridge is configured, the user's mobile device can remotely trigger tasks on this desktop machine. Even when no dispatch session is actively running, the bridge is ready to accept incoming tasks. This means the desktop is a remote execution target — a compromised mobile device or stolen phone could dispatch tasks that access files, connectors, and tools configured on the desktop.
+  - 📜 **Compliance**: Remote task execution introduces a new control plane that may not be covered by existing endpoint security policies. The mobile device effectively becomes a remote access vector to the desktop's Claude capabilities.
+  - 🤖 **AI enablement**: Dispatch is designed for users who want to start tasks from their phone and have them execute on a more capable desktop machine. Understanding bridge state is critical for assessing mobile-to-desktop AI data flows.
+- **Severity**: ⚠️ `WARN` — Dispatch bridge configuration means the desktop is a potential remote execution target.
+- **Recommendation**: Verify the user intentionally configured dispatch. Ensure the mobile device has adequate security controls (passcode, biometrics, MDM enrollment). Review what connectors and tools are available to dispatched tasks. Disable dispatch if the user does not need mobile-to-desktop task assignment.
+
+---
+
+### 📡 Dispatch Actively Accepting Tasks
+
+- **What**: Checks `hostLoopMode` in `local_*.json` session files. When `true`, the desktop is actively accepting and executing tasks dispatched from a mobile device. Reports the number of active dispatch sessions.
+- **Why it matters**:
+  - 🔴 **Risk**: Active dispatch means the desktop is currently processing or waiting for tasks from the mobile device. This is the highest-risk dispatch state — the phone is actively controlling desktop execution. All desktop capabilities (files, MCP servers, connectors, extensions) are available to dispatched tasks.
+  - 📜 **Compliance**: Active remote task execution should be logged and monitored. The mobile device is effectively a remote control for the desktop's AI agent.
+  - 🤖 **AI enablement**: Active dispatch sessions indicate the user is leveraging mobile-to-desktop workflows in real time.
+- **Severity**: ⚠️ `WARN` — Active dispatch is a high-autonomy state that merits immediate review.
+- **Recommendation**: Verify the user is actively using dispatch. If dispatch sessions persist when the user is not actively dispatching from their phone, investigate whether the session is stale or if the bridge configuration needs to be reset.
+
+---
+
+### 🔀 Three-State Display
+
+CLAUDIT displays dispatch in three states across all output formats:
+
+| State | Condition | Display |
+|-------|-----------|---------|
+| **OFF** | No bridge configured, no active sessions | `OFF` (green) |
+| **CONFIGURED** | `bridge-state.json` has `enabled: true` but no active `hostLoopMode` sessions | `CONFIGURED` (yellow) |
+| **ON** | Any `local_*.json` has `hostLoopMode: true` | `ON` (yellow) |
+
+---
+
+## 4. 🏢 Workspaces
+
+**Source files:** `local-agent-mode-sessions/<org>/<user>/` directories, `config.json` (DXT keys), `bridge-state.json`
+
+Claude Desktop can have multiple workspaces (accounts) active simultaneously — for example, a personal free account, a Teams subscription, and an Enterprise subscription. CLAUDIT detects and inventories all workspaces.
+
+---
+
+### 🔍 Workspace Detection
+
+- **What**: Enumerates user UUID directories under each org UUID in `local-agent-mode-sessions/`. Also discovers additional workspaces from `config.json` DXT allowlist keys (`dxt:allowlistEnabled:<userUUID>`) that may not have session directories. For each workspace, CLAUDIT collects:
+  - **User UUID** (truncated to 8 chars in display)
+  - **Account name** and **email** (from the first session file with data)
+  - **Session count** (number of `local_*.json` files)
+  - **Indicators**: DXT-managed (Enterprise), org-plugins (Teams/Enterprise), dispatch-bridge (active bridge)
+- **Why it matters**:
+  - 🔍 **Visibility**: Multiple workspaces mean the user has access to multiple Claude subscriptions, potentially with different capability levels and organizational controls. An Enterprise workspace may have DXT allowlists and blocklists while a personal workspace has no governance controls.
+  - 📜 **Compliance**: Organizations should know if users have personal Claude accounts alongside managed accounts. Personal accounts bypass organizational governance controls (extension allowlists, blocklists, plugin restrictions).
+  - 🤖 **AI enablement**: Workspace count and type indicators help administrators understand the user's Claude footprint and which workspaces have organizational controls.
+- **Severity**: ℹ️ `INFO` — Multiple workspaces are informational but important for understanding the user's full Claude configuration.
+- **Recommendation**: Review workspace indicators to understand which workspaces are organizationally managed (DXT-managed) versus personal. Ensure organizational governance controls are applied to the appropriate workspaces.
+
+---
+
+### 🏷️ Workspace Indicators
+
+| Indicator | Source | Meaning |
+|-----------|--------|---------|
+| **DXT-managed** | `config.json` → `dxt:allowlistEnabled:<userUUID>` is `true` | Workspace has organizational extension governance (Enterprise indicator) |
+| **org-plugins** | `remote_cowork_plugins/` directory exists under the user UUID | Workspace receives org-deployed plugins (Teams/Enterprise indicator) |
+| **dispatch-bridge** | `bridge-state.json` has `enabled: true` for this user UUID | Dispatch bridge is configured for this workspace |
+
+---
+
+### ⚠️ Limitations
+
+Plan type (Free, Pro, Max, Teams, Enterprise) is not stored in any locally accessible configuration file. CLAUDIT uses indirect indicators (DXT allowlist, remote plugins, bridge state) to infer workspace characteristics. The actual plan type is managed server-side by Anthropic.
+
+---
+
+## 5. 🔌 MCP Servers
 
 **Source file:** `claude_desktop_config.json` → `mcpServers`
 
@@ -181,7 +267,7 @@ MCP (Model Context Protocol) servers are external processes that Claude launches
 
 ---
 
-## 4. 🧩 Extensions (DXT)
+## 6. 🧩 Extensions (DXT)
 
 **Source file:** `~/Library/Application Support/Claude/extensions-installations.json`
 
@@ -213,7 +299,7 @@ DXT extensions are packaged plugins for Claude Desktop that provide tools and ca
 
 ---
 
-## 5. 📂 Extension Settings
+## 7. 📂 Extension Settings
 
 **Source directory:** `~/Library/Application Support/Claude/Claude Extensions Settings/*.json`
 
@@ -233,7 +319,7 @@ Per-extension settings files contain user-configured options, including filesyst
 
 ---
 
-## 6. 🛡️ Extension Governance (Blocklist & Allowlist)
+## 8. 🛡️ Extension Governance (Blocklist & Allowlist)
 
 **Source files:** `extensions-blocklist.json`, `config.json` (keys containing `dxt:allowlistEnabled`)
 
@@ -265,7 +351,7 @@ These checks examine organizational governance controls over extensions.
 
 ---
 
-## 7. 🔗 Plugins
+## 9. 🔗 Plugins
 
 **Source files:** `installed_plugins.json`, `remote_cowork_plugins/manifest.json`, marketplace directories, cache directories (per session)
 
@@ -306,7 +392,7 @@ Plugins extend Claude Cowork's capabilities. They come in three categories: inst
 
 ---
 
-## 8. 🪝 Plugin Hooks
+## 10. 🪝 Plugin Hooks
 
 **Source files:** `hooks/hooks.json` inside plugin directories (cowork cached plugins, CC marketplace plugins, remote plugins)
 
@@ -335,7 +421,7 @@ Plugin hooks are shell commands that plugins register to run at specific lifecyc
 
 ---
 
-## 9. 🌐 Connectors
+## 11. 🌐 Connectors
 
 **Source files:** `local_*.json` (session files) → `remoteMcpServersConfig`, `.mcp.json` (from remote plugins), extensions, MCP servers
 
@@ -365,7 +451,7 @@ Connectors represent all the external services and integrations that Claude can 
 
 ---
 
-## 10. 🎯 Skills
+## 12. 🎯 Skills
 
 **Source paths:** 9 different filesystem locations (see Architecture section)
 
@@ -406,7 +492,7 @@ Skills are SKILL.md files that define reusable prompts and instructions for Clau
 
 ---
 
-## 11. ⏰ Scheduled Tasks
+## 13. ⏰ Scheduled Tasks
 
 **Source file:** `scheduled-tasks.json` (per session)
 
@@ -436,7 +522,7 @@ Scheduled tasks are cron-scheduled autonomous Claude sessions. Each task has a c
 
 ---
 
-## 12. ⚙️ App Config (config.json)
+## 14. ⚙️ App Config (config.json)
 
 **Source file:** `~/Library/Application Support/Claude/config.json`
 
@@ -463,7 +549,7 @@ The app config contains application-level settings including OAuth tokens, netwo
 
 ---
 
-## 13. 💻 Claude Code Settings
+## 15. 💻 Claude Code Settings
 
 **Source file:** `~/.claude/settings.json`
 
@@ -483,7 +569,7 @@ Claude Code is the CLI-based Claude interface. Its settings file contains permis
 
 ---
 
-## 14. 🏃 Runtime State
+## 16. 🏃 Runtime State
 
 **Source:** System commands (`pgrep`, `pmset`, `crontab`, filesystem)
 
@@ -550,7 +636,7 @@ Runtime checks examine the live state of the system to detect Claude-related pro
 
 ---
 
-## 15. 🍪 Cookies
+## 17. 🍪 Cookies
 
 **Source files:** `~/Library/Application Support/Claude/Cookies`, `~/Library/Application Support/Claude/Cookies-journal`
 
@@ -569,7 +655,7 @@ Claude Desktop (as an Electron app) maintains browser-like cookie storage.
 
 ---
 
-## 16. 📊 Severity Level Reference
+## 18. 📊 Severity Level Reference
 
 CLAUDIT uses five severity levels. Here is what each means and when it is applied:
 
@@ -605,6 +691,8 @@ Here is a complete catalog of every `add_finding` call in CLAUDIT, organized by 
 | 14 | Runtime | Claude-related crontab entry | User's `crontab -l` output contains "claude" (case-insensitive) |
 | 15 | Runtime | Claude LaunchAgent(s) found | Plist file in `~/Library/LaunchAgents/` containing "claude" in filename |
 | 16 | Runtime | Debug directory is large | `~/Library/Application Support/Claude/debug/` exceeds 100 MB |
+| 17 | Dispatch | Dispatch bridge CONFIGURED | `bridge-state.json` has any entry with `enabled: true` |
+| 18 | Dispatch | Dispatch actively accepting tasks | Any `local_*.json` has `hostLoopMode: true` |
 
 ### 🔍 REVIEW Findings
 
@@ -621,6 +709,7 @@ Here is a complete catalog of every `add_finding` call in CLAUDIT, organized by 
 | 3 | Connectors | Web connectors authenticated | 1 or more web connectors found with active OAuth connections |
 | 4 | Claude Code | Permissions granted | `permissions.allow` array is non-empty in `~/.claude/settings.json` |
 | 5 | Runtime | Claude is running | `pgrep -fl Claude` returns results |
+| 6 | Workspaces | Multiple workspaces detected | More than 1 workspace (user UUID) found across session directories and config keys |
 
 ---
 
@@ -642,6 +731,8 @@ The following data is collected and displayed in the report but does **not** gen
 | Scheduled Tasks | Disabled tasks | Historical workflow inventory |
 | App Config | Network mode, device ID (ant-did) | Configuration context |
 | Disabled MCP Tools | Per-session disabled tool list with dangerous tool callout | Tool restriction inventory |
+| Workspaces | Workspace table (user UUID, account name, email, session count, indicators) | Multi-account inventory |
+| Dispatch | Three-state display (OFF/CONFIGURED/ON) | Mobile-to-desktop bridge state |
 | Cookies | Cookie file presence | Artifact inventory |
 
 ---
@@ -663,7 +754,9 @@ CLAUDIT also builds a **Recommendations** list at the end of the report. Recomme
 11. 📡 Remote plugins are deployed
 12. 📦 Cached (not installed) plugins exist
 13. 🔐 Web connectors are authenticated
+14. 📲 Dispatch bridge is configured (mobile-to-desktop)
+15. 📡 Dispatch is actively accepting tasks
 
 ---
 
-*This document was generated for CLAUDIT-SEC v2.2.0. Last updated: 2026-03-19.*
+*This document was generated for CLAUDIT-SEC v2.3.0. Last updated: 2026-03-31.*


### PR DESCRIPTION
  **Summary**

  - Add workspace/account detection: enumerates all user UUIDs under Claude Desktop's session
  directories, with account name, email, session count, and org indicators (DXT-managed, org-plugins,
  dispatch-bridge)
  - Add dispatch bridge detection via bridge-state.json, fixing false negatives where dispatch showed
  OFF despite being configured. Three states: OFF, CONFIGURED, ON
  - Fix Security Findings section to display all WARN findings — previously only showed findings from
  "Security" and "Runtime" sections, missing warnings from Cowork Settings, Extensions, Scheduled
  Tasks, and Workspaces

  **Details**

  New collector: collect_workspaces()
  - Enumerates user UUIDs under local-agent-mode-sessions/<org>/<user>/
  - Discovers additional workspaces via config.json DXT allowlist keys
  - Reads bridge-state.json for dispatch bridge enabled/consented state
  - Per-workspace indicators: DXT-managed (Enterprise), org-plugins (Teams/Enterprise), dispatch-bridge

  Dispatch three-state detection
  - hostLoopMode=true in session files → ON (actively accepting tasks)
  - bridge-state.json enabled=true → CONFIGURED (bridge set up but idle)
  - Neither → OFF
  - Previously only checked hostLoopMode, missing the configured-but-idle state

  Security Findings fix
  - ASCII and HTML renderers now show all WARN findings regardless of source section
  - Previously cherry-picked only Security section allowlist/blocklist and Runtime non-INFO findings

  Rendered in all output formats:
  - ASCII: WORKSPACES table + dispatch state in Cowork Settings + summary line
  - HTML: <details> workspace table + dispatch setting row
  - JSON: workspaces array + org_uuid + dispatchBridgeEnabled/dispatchBridgeConsented in cowork_prefs

  **Test plan**

  - zsh claude_audit.sh — verify WORKSPACES table, dispatch CONFIGURED in Cowork Settings, all WARNs in
   Security Findings
  - zsh claude_audit.sh --json | jq . — valid JSON, workspace array, dispatch bridge fields
  - zsh claude_audit.sh --html /tmp/test.html — workspace table, dispatch row, all WARNs in Security
  Findings
  - zsh claude_audit.sh -q — workspace table suppressed, summary line present, dispatch WARN visible
  - Multi-user scan (sudo zsh claude_audit.sh) — globals reset between users

  Generated with Claude Code